### PR TITLE
update readme to install fms mo without dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install -e .
 cd ..
 
 cd fms-model-optimizer
-pip install -e .
+pip install -e . --no-dependencies
 cd ..
 
 pip install -e .


### PR DESCRIPTION
- update readme to install fms mo without dependencies
- fms mo updates torch version due to torchvision and creates conflicts when used with aiu-fms-testing-utils 