### PR TITLE
updated with fix to dtype for aiu non-gptq models in test_decoders

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -313,6 +313,7 @@ def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
     get_model_kwargs = {}
     if not is_gptq:
         get_model_kwargs = {
+            "data_type": torch.float16,
             **model_path_kwargs,
             **micro_model_kwargs,
             **distributed_kwargs,

--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -313,7 +313,6 @@ def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
     get_model_kwargs = {}
     if not is_gptq:
         get_model_kwargs = {
-            "data_type": torch.float16,
             **model_path_kwargs,
             **micro_model_kwargs,
             **distributed_kwargs,
@@ -324,6 +323,7 @@ def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
     # prepare the AIU model
     model = get_model(
         device_type="cpu",
+        data_type=None if is_gptq else torch.float16,
         fused_weights=False,
         **gptq_kwargs_aiu,
         **get_model_kwargs,


### PR DESCRIPTION
for AIU non-gptq models, we should be using `torch.float16` for the data_type. The current tests were using None which was incorrect for some models.