### PR TITLE
fixed bug where cpu validation information is saved, even when loaded

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -247,6 +247,7 @@ def __load_validation_info(
     )
 
     if os.path.exists(full_path):
+        dprint(f"cpu validation info found for seed={seed} -- loading it")
         return load_validation_information(full_path, "logits", batch_size, tokenizer)
     else:
         return None
@@ -368,12 +369,12 @@ def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
             **padding_kwargs,
         )
 
-    if save_validation_info_outputs:
-        cpu_validation_info.save(
-            __get_validation_info_full_path(
-                model_path, batch_size, seq_length, max_new_tokens, 0
+        if save_validation_info_outputs:
+            cpu_validation_info.save(
+                __get_validation_info_full_path(
+                    model_path, batch_size, seq_length, max_new_tokens, 0
+                )
             )
-        )
     cpu_static_tokens = cpu_validation_info.get_info("tokens")
     eos_indexes = __find_eos_index(
         cpu_static_tokens, tokenizer.eos_token_id, seq_length, max_new_tokens
@@ -430,15 +431,15 @@ def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
                         attn_algorithm="math",
                         **padding_kwargs,
                     )
-                dprint(
-                    f"cpu validation info extracted for validation level 1 - iter={i}"
-                )
-                if save_validation_info_outputs:
-                    cpu_validation_info.save(
-                        __get_validation_info_full_path(
-                            model_path, batch_size, seq_length, max_new_tokens, i
-                        )
+                    dprint(
+                        f"cpu validation info extracted for validation level 1 - iter={i}"
                     )
+                    if save_validation_info_outputs:
+                        cpu_validation_info.save(
+                            __get_validation_info_full_path(
+                                model_path, batch_size, seq_length, max_new_tokens, i
+                            )
+                        )
                 cpu_static_tokens = cpu_validation_info.get_info("tokens")
                 eos_indexes = __find_eos_index(
                     cpu_static_tokens,


### PR DESCRIPTION
When running test_decoders, if cpu validation information was loaded, we would subsequently store it (which is not required -- it is the same information). We should only store cpu validation information if it was required to be computed on cpu. This could cause extra overhead, as well as cause write issues if 2 tests are accessing the same validation info.