### PR TITLE
Fixed bug with test_decoders where distributed_strategy was not set properly

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -327,7 +327,7 @@ def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
 
     distributed_kwargs = {}
     if USE_DISTRIBUTED:
-        distributed_kwargs["distr_param"] = "tp"
+        distributed_kwargs["distributed_strategy"] = "tp"
         distributed_kwargs["group"] = dist.group.WORLD
 
     get_model_kwargs = {}


### PR DESCRIPTION
This PR sets the proper passes in the proper distributed strategy in test_decoders.py. In it's current state, distributed_strategy="tp" would be assumed when the world_size > 1 (so no issues exist), however this calls `get_model` with the proper params explicitly.