### PR TITLE
Multi-aiu bug fixes

### DIFF
--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -77,7 +77,7 @@ class ValidationInfo:
         """
         dprint(f"saving validation info to {save_dir_path}")
         if not os.path.exists(save_dir_path):
-            os.makedirs(save_dir_path)
+            os.makedirs(save_dir_path, exist_ok=True)
 
         for sentence_i, sentence in enumerate(self._validation_info_list):
             file_path = os.path.join(save_dir_path, f"{sentence_i}.pt")

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -76,8 +76,7 @@ class ValidationInfo:
         :param save_dir_path: the path to save to
         """
         dprint(f"saving validation info to {save_dir_path}")
-        if not os.path.exists(save_dir_path):
-            os.makedirs(save_dir_path, exist_ok=True)
+        os.makedirs(save_dir_path, exist_ok=True)
 
         for sentence_i, sentence in enumerate(self._validation_info_list):
             file_path = os.path.join(save_dir_path, f"{sentence_i}.pt")

--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -327,7 +327,7 @@ def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
 
     distributed_kwargs = {}
     if USE_DISTRIBUTED:
-        distributed_kwargs["distr_param"] = "tp"
+        distributed_kwargs["distributed_strategy"] = "tp"
         distributed_kwargs["group"] = dist.group.WORLD
 
     get_model_kwargs = {}


### PR DESCRIPTION
This PR addresses 2 issues:

1. The parameter name accepted by `get_model()` [function](https://github.com/foundation-model-stack/foundation-model-stack/blob/517315ca3b840e46117614ef19ac0e8da76a5c0c/fms/models/__init__.py#L295) in `fms` is `distributed_strategy` as opposed to `distr_param`
2. Handling the exception that gets thrown due to race condition in dir creation when using tp 