### PR TITLE
Only include attn_algorithm in forward if specified

### DIFF
--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -193,9 +193,11 @@ def extract_validation_information(model, input_ids, max_new_tokens, post_iterat
     max_seq_len = model.config.max_expected_seq_len
 
     # Add only_last_token optimization
-    extra_generation_kwargs = {**padding_kwargs, "attn_algorithm": attn_algorithm}
+    extra_generation_kwargs = {**padding_kwargs}
     if only_last_token:
         extra_generation_kwargs["only_last_token"] = only_last_token
+    if attn_algorithm is not None:
+        extra_generation_kwargs["attn_algorithm"] = attn_algorithm
 
     result = generate(
         model,


### PR DESCRIPTION
With the new changes to fms (https://github.com/foundation-model-stack/foundation-model-stack/pull/408), `attn_algorithm` is not a required param in forward. Adding it during inference can cause slight changes in graph produced by pytorch, so safer and more consistent to keep it out.