### PR TITLE
Fix crash when timings only has one element

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -671,11 +671,12 @@ def infer(use_cache, do_sample, warmup):
         elif args.timing == "per-token":
             if not warmup:
                 dprint(f"First-token latency: {timings[0]*1000:.3f} ms")
-                dprint(f"Average next-token latency: {np.mean(timings[1:])*1000:.3f} ms")
                 dprint(f"Average next-token latency (including first token): {np.mean(timings)*1000:.3f} ms")
-                dprint(f"Max next-token latency: {np.max(timings[1:])*1000:.3f} ms (token #{np.argmax(timings[1:]) + 2})")
-                dprint(f"Min next-token latency: {np.min(timings[1:])*1000:.3f} ms (token #{np.argmin(timings[1:]) + 2})")
-                dprint(f"Std deviation of next-token latencies: {np.std(timings[1:])*1000:.3f} ms")
+                if len(timings) > 1:
+                    dprint(f"Average next-token latency: {np.mean(timings[1:])*1000:.3f} ms")
+                    dprint(f"Max next-token latency: {np.max(timings[1:])*1000:.3f} ms (token #{np.argmax(timings[1:]) + 2})")
+                    dprint(f"Min next-token latency: {np.min(timings[1:])*1000:.3f} ms (token #{np.argmin(timings[1:]) + 2})")
+                    dprint(f"Std deviation of next-token latencies: {np.std(timings[1:])*1000:.3f} ms")
             timings = [f"{t*1000:.3f}" for t in timings]
             dprint(f"Per-token timing information: {', '.join(timings)} ms")
     if len(result.shape) == 1:


### PR DESCRIPTION
In the edge case where only one token has been generated, not having this would cause a crash.