### PR TITLE
added an option to skip assertions in validation

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -100,7 +100,7 @@ if isinstance(common_seq_lengths, str):
 if isinstance(common_max_new_tokens, str):
     common_max_new_tokens = [int(mnt) for mnt in common_max_new_tokens.split(",")]
 
-# pass metrics to skip as a comma separated list (ce, mean_diff)
+# pass metrics to skip as a comma separated list (ce,mean_diff)
 if isinstance(skip_assertions, str):
     _skip_assertions = []
     for metric in skip_assertions.split(","):


### PR DESCRIPTION
In some cases, we only want to fail on some metrics or none. This PR will add the ability to skip assertions in test_decoders.py by providing the FMS_TEST_SHAPES_SKIP_ASSERTIONS environment variable which is a comma separated list of metrics. If the user provides all metrics, this will only assert that compilation and inference was successful.