### PR TITLE
removed HF_HOME as we are now matching huggingface cache implementation in fms

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -34,8 +34,6 @@ try:
 except ImportError:
     GPTQ_ENABLED = False
 
-ORIGINAL_HF_HOME = os.environ.get("HF_HOME", None)
-
 # Add models to test here
 LLAMA_3p1_8B_INSTRUCT = "meta-llama/Llama-3.1-8B-Instruct"
 GRANITE_3p2_8B_INSTRUCT = "ibm-granite/granite-3.2-8b-instruct"
@@ -159,10 +157,6 @@ def reset_compiler():
     torch.compiler.reset()
     torch._dynamo.reset()
     os.environ.pop("COMPILATION_MODE", None)
-    if ORIGINAL_HF_HOME is None:
-        os.environ.pop("HF_HOME", None)
-    else:
-        os.environ["HF_HOME"] = ORIGINAL_HF_HOME
 
 
 # TODO: Currently, gptq does not have the same level of support as non-gptq models for get_model. This method provides the extra requirements for gptq for get_model,
@@ -303,9 +297,6 @@ def __maybe_reset_model(model, is_gptq):
 def test_common_shapes(model_path, batch_size, seq_length, max_new_tokens):
     torch.manual_seed(42)
     os.environ["COMPILATION_MODE"] = "offline_decoder"
-
-    if "HF_HOME" not in os.environ:
-        os.environ["HF_HOME"] = "/tmp/models/hf_cache"
 
     dprint(
         f"testing model={model_path}, batch_size={batch_size}, seq_length={seq_length}, max_new_tokens={max_new_tokens}, micro_model={USE_MICRO_MODELS}"

--- a/tests/models/test_encoders.py
+++ b/tests/models/test_encoders.py
@@ -10,8 +10,6 @@ from aiu_fms_testing_utils.utils.aiu_setup import dprint
 import os
 import numpy as np
 
-ORIGINAL_HF_HOME = os.environ.get("HF_HOME", None)
-
 # Add models to test here
 ROBERTA_SQUAD_V2 = "deepset/roberta-base-squad2"
 
@@ -81,10 +79,6 @@ def reset_compiler():
     torch.compiler.reset()
     torch._dynamo.reset()
     os.environ.pop('COMPILATION_MODE', None)
-    if ORIGINAL_HF_HOME is None:
-        os.environ.pop('HF_HOME', None)
-    else:
-        os.environ['HF_HOME'] = ORIGINAL_HF_HOME
 
 encoder_paths = ["deepset/roberta-base-squad2"]
 common_encoder_shapes = list(itertools.product(encoder_paths, common_batch_sizes, common_seq_lengths))
@@ -92,9 +86,6 @@ common_encoder_shapes = list(itertools.product(encoder_paths, common_batch_sizes
 @pytest.mark.parametrize("model_path,batch_size,seq_length", common_encoder_shapes)
 def test_common_shapes(model_path, batch_size, seq_length):
     os.environ["COMPILATION_MODE"] = "offline"
-
-    if "HF_HOME" not in os.environ:
-        os.environ["HF_HOME"] = "/tmp/models/hf_cache"
     
     dprint(f"testing model={model_path}, batch_size={batch_size}, seq_length={seq_length}")
 

--- a/tests/models/test_model_expectations.py
+++ b/tests/models/test_model_expectations.py
@@ -13,9 +13,6 @@ import os
 
 os.environ["COMPILATION_MODE"] = "offline"
 
-if "HF_HOME" not in os.environ:
-    os.environ["HF_HOME"] = "/tmp/models/hf_cache"
-
 model_dir = os.environ.get("FMS_TESTING_MODEL_DIR", "/tmp/models")
 LLAMA_3p1_8B_INSTRUCT = "meta-llama/Llama-3.1-8B-Instruct"
 GRANITE_3p2_8B_INSTRUCT = "ibm-granite/granite-3.2-8b-instruct"


### PR DESCRIPTION
FMS is now matching huggingface logic for its cache so no need for an explicit HF_HOME environment variable https://github.com/foundation-model-stack/foundation-model-stack/pull/417