### PR TITLE
Adds new metrics calculated

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -42,6 +42,7 @@ GRANITE_3p2_8B_INSTRUCT = "ibm-granite/granite-3.2-8b-instruct"
 GRANITE_3p3_8B_INSTRUCT = "ibm-granite/granite-3.3-8b-instruct"
 GRANITE_20B_CODE_INSTRUCT_8K = "ibm-granite/granite-20b-code-instruct-8k"
 LLAMA_3p1_70B_INSTRUCT = "meta-llama/Llama-3.1-70B-Instruct"
+MISTRAL_0p3_7B_INSTRUCT = "mistralai/Mistral-7B-Instruct-v0.3"
 
 micro_model_mapping = {
     LLAMA_3p1_8B_INSTRUCT: os.path.join(MICRO_MODELS_HOME, "llama-3.1-8b-layers-3-step-24000"),
@@ -72,6 +73,7 @@ common_model_paths = os.environ.get(
         GRANITE_3p3_8B_INSTRUCT,
         GRANITE_20B_CODE_INSTRUCT_8K,
         LLAMA_3p1_70B_INSTRUCT,
+        MISTRAL_0p3_7B_INSTRUCT
     ],
 )
 # for validation level 1, the default is a failure rate of 1%
@@ -145,24 +147,33 @@ common_shapes = list(
 # threshold key is (model_id, is_tiny_model)
 fail_thresholds = {
     (LLAMA_3p1_8B_INSTRUCT, False): (
-        2.6994638133048965,
-        0.00047589250549208347,
+        2.7080255031585696,
+        0.0004068055667448795,
     ),
     (GRANITE_3p2_8B_INSTRUCT, False): (
         2.3919514417648315,
         0.0005767398688476533,
+    ),
+    (GRANITE_3p2_8B_INSTRUCT, True): (
+        2.7449850964546205,
+        0.00018840670207282534,
     ),
     (GRANITE_3p3_8B_INSTRUCT, False): (
         2.4444521379470827,
         0.0004970188625156878,
     ),
     (GRANITE_20B_CODE_INSTRUCT_8K, False): (
-        2.640706129074097,
-        0.00034344267623964697,
+        2.646075320243838,
+        0.0003458251833217223,
     ),
+    # TODO: run llama 70B with 1,2,4,8 batches
     (LLAMA_3p1_70B_INSTRUCT, False): (
         2.841279556751251,
         0.0044301633024588115,
+    ),
+    (MISTRAL_0p3_7B_INSTRUCT, False): (
+        2.846206340789795,
+        0.0008768103783950205,
     ),
 }
 # custom weight adaptation to be used in future. For instance if we would like to add some other adaptation, we can register it with this custom adapter


### PR DESCRIPTION
Adds/updates metrics for the models; Shapes are:

```python
max_new_tokens = [128]
batch_sizes = [1,2,4,8]
sequence_lengths = [64, 2048]
default_dtypes = ["fp16"]
```
Models:
- mistralai/Mistral-7B-Instruct-v0.3
```bash
$ python3 get_thresholds.py --models mistralai/Mistral-7B-Instruct-v0.3 --metrics diff_mean ce --file_base /fms-generate-metrics/output
found 8 metric files
mistralai--Mistral-7B-Instruct-v0.3 diff_mean 0.0008768103783950205
found 8 metric files
mistralai--Mistral-7B-Instruct-v0.3 ce 2.846206340789795
```
- micro: /fms-generate-metrics/granite-3.2-8b-layers-3-step-100000
```bash
$ python3 get_thresholds.py --models /fms-generate-metrics/granite-3.2-8b-layers-3-step-100000 --metrics diff_mean ce --file_base /fms-generate-metrics/output
found 8 metric files
--fms-generate-metrics--granite-3.2-8b-layers-3-step-100000 diff_mean 0.00018840670207282534
found 8 metric files
--fms-generate-metrics--granite-3.2-8b-layers-3-step-100000 ce 2.7449850964546205
```
- meta-llama/Llama-3.1-8B-Instruct
```bash
$ python3 get_thresholds.py --models meta-llama/Llama-3.1-8B-Instruct --metrics diff_mean ce --file_base /fms-generate-metrics/output
found 8 metric files
meta-llama--Llama-3.1-8B-Instruct diff_mean 0.0004068055667448795
found 8 metric files
meta-llama--Llama-3.1-8B-Instruct ce 2.7080255031585696
```
- ibm-granite/granite-20b-code-instruct-8k
```bash
$ python3 get_thresholds.py --models ibm-granite/granite-20b-code-instruct-8k --metrics diff_mean ce --file_base /fms-generate-metrics/output
found 8 metric files
ibm-granite--granite-20b-code-instruct-8k diff_mean 0.0003458251833217223
found 8 metric files
ibm-granite--granite-20b-code-instruct-8k ce 2.646075320243838
```
**TODO:** Llama 70B - need more GPUs to run it. 