### PR TITLE
Fix max allowed lengths for prompts larger than 4096

### DIFF
--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -188,7 +188,6 @@ def load_validation_information(validation_path, validation_files_type, batch_si
     return ValidationInfo(validation_info)
 
 def extract_validation_information(model, input_ids, max_new_tokens, post_iteration_hook, attn_algorithm=None, eos_token_id = None, only_last_token=False, timing="", **extra_kwargs):
-    max_seq_len = model.config.max_expected_seq_len
     attention_specific_kwargs = {}
     if "paged" in extra_kwargs["attn_name"]:
         from aiu_fms_testing_utils.utils.paged import generate
@@ -196,7 +195,7 @@ def extract_validation_information(model, input_ids, max_new_tokens, post_iterat
         # TODO: Add a unified generation dependent on attn_type
         from fms.utils.generation import generate
         attention_specific_kwargs["contiguous_cache"] = True
-        attention_specific_kwargs["max_seq_len"] = max_seq_len
+        attention_specific_kwargs["max_seq_len"] = input_ids.shape[1] + max_new_tokens
 
     # Add only_last_token optimization
     extra_generation_kwargs = {**extra_kwargs}
@@ -208,7 +207,6 @@ def extract_validation_information(model, input_ids, max_new_tokens, post_iterat
     result = generate(
         model,
         input_ids,
-        max_seq_len=input_ids.shape[1] + max_new_tokens,
         max_new_tokens=max_new_tokens,
         use_cache=True,
         do_sample=False,

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -208,6 +208,7 @@ def extract_validation_information(model, input_ids, max_new_tokens, post_iterat
     result = generate(
         model,
         input_ids,
+        max_seq_len=input_ids.shape[1] + max_new_tokens,
         max_new_tokens=max_new_tokens,
         use_cache=True,
         do_sample=False,

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -53,6 +53,7 @@ def warmup_model(
         generate(
             model,
             _warmup_input_ids,
+            max_seq_len=_warmup_input_ids.shape[1] + max_new_tokens,
             max_new_tokens=_max_new_tokens,
             do_sample=False,
             use_cache=use_cache,

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -30,6 +30,7 @@ def warmup_model(
         # TODO: Add a unified generation dependent on attn_type
         from fms.utils.generation import generate
         attention_specific_kwargs["contiguous_cache"] = True
+        attention_specific_kwargs["max_seq_len"] = input_ids.shape[1] + max_new_tokens
 
     dprint("AIU warmup")
     pt_compile_model_time = time.time()
@@ -53,7 +54,6 @@ def warmup_model(
         generate(
             model,
             _warmup_input_ids,
-            max_seq_len=_warmup_input_ids.shape[1] + max_new_tokens,
             max_new_tokens=_max_new_tokens,
             do_sample=False,
             use_cache=use_cache,

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -27,7 +27,6 @@ def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
 def generate(
     model: Union[Callable, torch.nn.Module],
     input_ids: torch.Tensor,
-    max_seq_len: int = 4096,
     max_new_tokens: int = 256,
     temperature: float = 1.0,
     top_k: int = 10,
@@ -55,7 +54,6 @@ def generate(
         model: A function or nn.Module that takes a batch of input_ids and
             returns logits
         input_ids: a rectangular tensor of input_ids (batch x seq)
-        max_seq_len: the sequence length of the model
         max_new_tokens: max tokens to generate
         temperature: temperature of softmax when sampling
         top_k: only search among top k tokens

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -27,6 +27,7 @@ def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
 def generate(
     model: Union[Callable, torch.nn.Module],
     input_ids: torch.Tensor,
+    max_seq_len: int = 4096,
     max_new_tokens: int = 256,
     temperature: float = 1.0,
     top_k: int = 10,

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -717,6 +717,7 @@ def infer(use_cache, do_sample, warmup):
     result = generate(
         model,
         ids,
+        max_seq_len=ids.shape[1] + args.max_new_tokens,
         max_new_tokens=args.max_new_tokens,
         use_cache=use_cache,
         do_sample=do_sample,

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -713,11 +713,11 @@ def infer(use_cache, do_sample, warmup):
     attention_specific_kwargs = {}
     if attn_name == "sdpa_causal":
         attention_specific_kwargs["contiguous_cache"] = True
+        attention_specific_kwargs["max_seq_len"] = ids.shape[1] + args.max_new_tokens
 
     result = generate(
         model,
         ids,
-        max_seq_len=ids.shape[1] + args.max_new_tokens,
         max_new_tokens=args.max_new_tokens,
         use_cache=use_cache,
         do_sample=do_sample,

--- a/tests/utils/test_paged.py
+++ b/tests/utils/test_paged.py
@@ -39,7 +39,6 @@ def test_paged_equivalence():
         result_paged = paged_generate(
             _model_mock,
             ids,
-            max_seq_len=ids.shape[1] + 5,
             max_new_tokens=5,
             do_sample=False,
             use_cache=True,

--- a/tests/utils/test_paged.py
+++ b/tests/utils/test_paged.py
@@ -29,6 +29,7 @@ def test_paged_equivalence():
         result = generate(
             _model_mock,
             ids,
+            max_seq_len=ids.shape[1] + 5,
             max_new_tokens=5,
             do_sample=False,
             use_cache=True,
@@ -38,6 +39,7 @@ def test_paged_equivalence():
         result_paged = paged_generate(
             _model_mock,
             ids,
+            max_seq_len=ids.shape[1] + 5,
             max_new_tokens=5,
             do_sample=False,
             use_cache=True,


### PR DESCRIPTION
This takes cares of an oversight that prevented prompts longer than 4k from being run with generate()