### PR TITLE
Use already set FLEX_DEVICE in validation/conftest

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pip install -e .
 Run with AIU instead of, default, senulator.
 ```shell
 export FLEX_COMPUTE=SENTIENT
-export FLEX_DEVICE=VFIO
+export FLEX_DEVICE=PF
 ```
 
 Optional envars to supress debugging output:

--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -330,7 +330,7 @@ else:
         print("must set AIU_WORLD_RANK_0")
         exit()
     os.environ["FLEX_COMPUTE"] = "SENTIENT"
-    os.environ["FLEX_DEVICE"] = "VFIO"
+    os.environ.setdefault("FLEX_DEVICE", "PF")
 
 aiu_device = torch.device("cpu")
 if default_dtype is not None:

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -18,7 +18,7 @@ def pytest_sessionstart(session):
 
     os.environ.setdefault("COMPILATION_MODE", "offline_decoder")
     os.environ["FLEX_COMPUTE"] = "SENTIENT"
-    os.environ["FLEX_DEVICE"] = "PF"
+    os.environ.setdefault("FLEX_DEVICE", "PF")
 
     os.environ.setdefault("DTLOG_LEVEL", "error")
     os.environ.setdefault("DT_DEEPRT_VERBOSE", "-1")


### PR DESCRIPTION
Minor updates:
1. Allow an already FLEX_DEVICE env variable to be used in conftest.py and validation.py
2. Change VFIO -> PF 