### PR TITLE
Add Cache Miss/Hit Test

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -599,9 +599,6 @@ def _get_device_validation_information(
         if cpu_validation_info is not None:
             return cpu_validation_info
 
-        if cpu_validation_info is not None:
-            return cpu_validation_info
-
     # overrides for validation info that are device specific
     device_dependent_kwargs = {}
     if device == "cpu":


### PR DESCRIPTION
This PR builds on top of https://github.com/foundation-model-stack/aiu-fms-testing-utils/pull/20 and https://github.com/foundation-model-stack/aiu-fms-testing-utils/pull/93 to add a cache for testing using the refactored version of the test to allow some code reuse. #93 should probably be merged first (splitting this out for readability).

Summary of changes (wrt the original cache test PR)
    - Makes sure gptq kwargs are passed through to the AIU model
    - Makes sure `options={"sendnn.dynamic": COMPILE_DYNAMIC_SENDNN}` is passed consistently
    - Clears the torch sendnn `.cache` - the current PR can break if the cache test runs second since the cache paths aren't actually reset in torch sendnn. We reset the compiler settings and clear the directory, but don't clear the spyre cache object in the current PR, which causes alignment issues if the cache test doesn't run first
    - The current PR runs the check as two tests (cache miss -> cache hit); moves the cache miss test to run as a fixture to set things up so that we can just run cache hit as the test

Note that there is still some weirdness around how micro models are handled, mostly due to the way we configure common models paths / micro model usage and also check thresholds based on whether micro models exist.