### PR TITLE
Improve FMS-MO dependency and pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ aiu-fms-testing-utils.egg-info
 *.pyc
 */**/*.pyc
 .vscode
-aiu-fms-testing-utils.egg-info
 export_deeprt
 export_dtcompiler
 *.egg-info
+
+aiu_fms_testing_utils/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers=[
 ]
 dependencies = [
 "ibm-fms>=1.1.0,<2.0",
-"fms-model-optimizer>=0.5.0,<1.0",
+"fms-model-optimizer[fp8]>=0.5.0,<1.0",
 "sentencepiece>=0.2.0,<0.3.0",
 "numpy>=1.26.4,<2.3.0",
 "transformers>=4.45,<4.54",
@@ -47,6 +47,10 @@ dev = ["wheel>=0.42.0,<1.0", "packaging>=23.2,<25"]
 
 [tool.setuptools_scm]
 version_file = "aiu_fms_testing_utils/_version.py"
+
+[tool.setuptools.packages.find]
+where = [""]
+include = ["aiu_fms_testing_utils"]
 
 [project.urls]
 Homepage = "https://github.com/foundation-model-stack/aiu-fms-testing-utils"


### PR DESCRIPTION
This PR adds the FP8 dependency for fms-mo so we can run fp8 checkpoints from AFTU.

Also improve the `.gitignore` and packaging.