### PR TITLE
resolve package would be ignore  build warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ version_file = "aiu_fms_testing_utils/_version.py"
 
 [tool.setuptools.packages.find]
 where = [""]
-include = ["aiu_fms_testing_utils"]
+include = ["aiu_fms_testing_utils/*"]
 
 [project.urls]
 Homepage = "https://github.com/foundation-model-stack/aiu-fms-testing-utils"


### PR DESCRIPTION
Resolve 2 warnings
https://github.com/foundation-model-stack/aiu-fms-testing-utils/actions/runs/16793638183/job/47559867964#step:5:86
```
        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'aiu_fms_testing_utils.testing' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'aiu_fms_testing_utils.testing' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'aiu_fms_testing_utils.testing' to be distributed and are
        already explicitly excluding 'aiu_fms_testing_utils.testing' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************
```

To verify, run the following:
```
python -m build
```
there should be no warnings
/cc @tharapalanivel @JRosenkranz @ani300 