### PR TITLE
Fix import in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ version_file = "aiu_fms_testing_utils/_version.py"
 
 [tool.setuptools.packages.find]
 where = [""]
-include = ["aiu_fms_testing_utils/*"]
+include = ["aiu_fms_testing_utils", "aiu_fms_testing_utils*"]
 
 [project.urls]
 Homepage = "https://github.com/foundation-model-stack/aiu-fms-testing-utils"


### PR DESCRIPTION
This PR is to resolve the error we're seeing below
```
>>> from aiu_fms_testing_utils.utils.aiu_setup import aiu_setup, rank, world_size
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'aiu_fms_testing_utils'
```