### PR TITLE
fixed bug when calling encode on loaded prompts

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -622,7 +622,7 @@ if args.prompt_path != "":
         prompts.append(
             tokenizer.encode(
                 prompt_file_path.read_text(encoding="utf-8"), return_tensors="pt"
-            )
+            ).squeeze(0)
         )
 
 else:

--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -542,7 +542,7 @@ if args.prompt_path != "":
         prompts.append(
             tokenizer.encode(
                 prompt_file_path.read_text(encoding="utf-8"), return_tensors="pt"
-            )
+            ).squeeze(0)
         )
 
 else:


### PR DESCRIPTION
After switching to huggingface tokenizer, needed to fix shape of prompts that are loaded from files following an encode call.