### PR TITLE
Fix encode shape bug for validation_info load

### DIFF
--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -208,7 +208,7 @@ def load_validation_information(
                     "tokens": tokenizer.encode(
                         validation_file_path.read_text(encoding="utf-8"),
                         return_tensors="pt",
-                    ),
+                    ).squeeze(0),
                     "logits": None,
                 }
             )


### PR DESCRIPTION
Missed squeezing tensor during loading when using hf transformers encode method