### PR TITLE
Fix roberta tokenizer selection

### DIFF
--- a/aiu_fms_testing_utils/utils/encoders_utils.py
+++ b/aiu_fms_testing_utils/utils/encoders_utils.py
@@ -65,7 +65,7 @@ class EncoderQAInfer:
         args: argparse.Namespace,
     ) -> None:
         self.model = model
-        self.tokenizer = tokenizer.tokenizer  # extract original HF tokenizer
+        self.tokenizer = tokenizer
         self.args = args
 
         self.question_column_name = ""


### PR DESCRIPTION
Update tokenizer selection for the QuestionAnswering Encoder to directly use the HF tokenizer, instead of trying to load it via the FMS tokenizer (tokenizer behavior was changed to HF direct use in #65).