### PR TITLE
Save CPU info for Multi-AIU test_decoders run

### DIFF
--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -684,13 +684,13 @@ def test_common_shapes(
         dprint(f"mean diff failure rate: {diff_failure_rate}")
         dprint(f"cross entropy loss failure rate: {ce_failure_rate}")
         if "mean_diff" not in skip_assertions:
-            assert (
-                diff_failure_rate < failure_rate_threshold
-            ), f"failure rate for mean diff was too high: {diff_failure_rate}"
+            assert diff_failure_rate < failure_rate_threshold, (
+                f"failure rate for mean diff was too high: {diff_failure_rate}"
+            )
         if "ce" not in skip_assertions:
-            assert (
-                ce_failure_rate < failure_rate_threshold
-            ), f"failure rate for cross entropy loss was too high: {ce_failure_rate}"
+            assert ce_failure_rate < failure_rate_threshold, (
+                f"failure rate for cross entropy loss was too high: {ce_failure_rate}"
+            )
 
         print("passed validation level 1")
     else:


### PR DESCRIPTION
Currently, when running test_decoders.py in a Multi-AIU [Jenkins job](https://wcp-ai-foundation-team-jenkins.swg-devops.com/job/fms-granite-3.3-8b-instruct-tp), CPU validation info is not saved. This was originally disabled because simultaneous saving from all AIUs could corrupt the CPU info file. To address this, for multi-AIU runs we now save CPU validation info only from rank 0.