### PR TITLE
Include version in validation info outputs

### DIFF
--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -404,6 +404,7 @@ def print_failed_cases(failed_cases, aiu_tokens, validation_tokens, tokenizer):
             f"In sentence {sentence_index + 1}/{len(aiu_tokens)}, token {token_index}, AIU outputs {aiu_token} instead of {validation_token} -- AIU val={aiu_str} -- CPU val={validation_str}"
         )
 
+
 def get_validation_info_path(
     validation_info_dir: str,
     model_variant: str,
@@ -412,16 +413,17 @@ def get_validation_info_path(
     max_new_tokens: int,
     seed: int,
     attn_type: str,
-    aftu_version: Optional[Tuple[int,int,int]] = None,
+    aftu_version: Optional[Tuple[int, int, int]] = None,
     device_type: str = "cpu",
     dtype: str = "fp16",
 ):
     if aftu_version is None:
         aftu_version = version_tuple
 
-    validation_file_name = f"{get_default_validation_prefix(model_variant, max_new_tokens, batch_size, seq_length, dtype, attn_type, ".".join([str(_) for _ in aftu_version[:3]]))}.{device_type}_validation_info.{seed}.out"
+    validation_file_name = f"{get_default_validation_prefix(model_variant, max_new_tokens, batch_size, seq_length, dtype, attn_type, '.'.join([str(_) for _ in aftu_version[:3]]))}.{device_type}_validation_info.{seed}.out"
     full_path = os.path.join(validation_info_dir, validation_file_name)
     return full_path
+
 
 def __decrement_version(version: Tuple[int, int, int]):
     """
@@ -437,6 +439,7 @@ def __decrement_version(version: Tuple[int, int, int]):
     else:
         return None
 
+
 def find_validation_info_path(
     validation_info_dir: str,
     model_variant: str,
@@ -445,7 +448,7 @@ def find_validation_info_path(
     max_new_tokens: int,
     seed: int,
     attn_type: str,
-    aftu_version: Optional[Tuple[int,int,int]] = None,
+    aftu_version: Optional[Tuple[int, int, int]] = None,
     version_allow_decrement: bool = False,
     device_type: str = "cpu",
     dtype: str = "fp16",
@@ -458,11 +461,22 @@ def find_validation_info_path(
         loc_version_tuple = version_tuple[:3]
     else:
         loc_version_tuple = aftu_version
-    
+
     result_path: Optional[str] = None
-    
+
     while result_path is None and loc_version_tuple is not None:
-        full_path = get_validation_info_path(validation_info_dir, model_variant, batch_size, seq_length, max_new_tokens, seed, attn_type, loc_version_tuple, device_type, dtype)
+        full_path = get_validation_info_path(
+            validation_info_dir,
+            model_variant,
+            batch_size,
+            seq_length,
+            max_new_tokens,
+            seed,
+            attn_type,
+            loc_version_tuple,
+            device_type,
+            dtype,
+        )
         # if the path is found, we are done searching and can return
         if os.path.exists(full_path):
             result_path = full_path

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -3,8 +3,8 @@ from typing import List, Tuple, Callable, MutableMapping, Any, Optional
 
 import torch
 from aiu_fms_testing_utils.utils.aiu_setup import dprint
-import os
 from aiu_fms_testing_utils._version import version_tuple
+import os
 
 
 class LogitsExtractorHook(
@@ -261,7 +261,7 @@ def extract_validation_information(
     **extra_kwargs,
 ):
     attention_specific_kwargs = {}
-    if "paged" in extra_kwargs["attn_name"]:
+    if "paged" in extra_kwargs.get("attn_name", "sdpa"):
         from aiu_fms_testing_utils.utils.paged import generate
     else:
         # TODO: Add a unified generation dependent on attn_type

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -130,8 +130,22 @@ def get_default_validation_prefix(
     seq_length: int,
     dtype: str,
     attn_type: str,
+    aftu_version: str,
 ):
-    return f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}"
+    """
+    Args:
+        model_id (str): model name used
+        max_new_tokens (int): number of max new tokens to generate
+        batch_size (int): batch size used
+        seq_length (int):sequence length used
+        dtype (str): data type
+        attn_type (str): type of attention
+        aftu_version (str): introduced in v0.3.0 to track changed in log
+
+    Returns:
+        str: A prefix that will be prepended to the file name
+    """
+    return f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}.{aftu_version}"
 
 
 def load_validation_information(

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -18,7 +18,6 @@ import math
 import contextlib
 import warnings
 
-
 @contextlib.contextmanager
 def stagger_region(limit: int):
     """

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -18,6 +18,7 @@ import math
 import contextlib
 import warnings
 
+
 @contextlib.contextmanager
 def stagger_region(limit: int):
     """

--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -4,8 +4,6 @@ import pytest
 from fms.models import get_model
 from fms.utils.generation import pad_input_ids
 import itertools
-import warnings
-import re
 import torch
 from torch import distributed as dist
 from aiu_fms_testing_utils.testing.validation import (
@@ -18,18 +16,16 @@ from aiu_fms_testing_utils.testing.validation import (
     load_validation_information,
     validate_level_0,
     top_k_loss_calculator,
-    find_validation_info_path
+    find_validation_info_path,
 )
 from aiu_fms_testing_utils.utils import (
     warmup_model,
     sample_sharegpt_requests,
 )
-from typing import Tuple
 import json
 from transformers import AutoTokenizer
 
 from aiu_fms_testing_utils.utils.aiu_setup import dprint, aiu_dist_setup
-from aiu_fms_testing_utils._version import version
 
 import os
 
@@ -365,12 +361,20 @@ def __load_validation_info(
     model_path, batch_size, seq_length, max_new_tokens, tokenizer, seed, attn_type: str
 ):
     # if path doesn't exist and paged isn't in the attention name, remove `attn_type` and recheck again, warn that we will no longer in the future have paths without 'attn_type'
-    full_path = find_validation_info_path(validation_info_dir, model_path, batch_size, seq_length, max_new_tokens, seed, attn_type, version_allow_decrement=True, dtype=CPU_DTYPE)
+    full_path = find_validation_info_path(
+        validation_info_dir,
+        model_path,
+        batch_size,
+        seq_length,
+        max_new_tokens,
+        seed,
+        attn_type,
+        version_allow_decrement=True,
+        dtype=CPU_DTYPE,
+    )
     if full_path is not None:
         dprint(f"cpu validation info found for seed={seed} -- loading it")
-        return load_validation_information(
-            full_path, "logits", batch_size, tokenizer
-        )
+        return load_validation_information(full_path, "logits", batch_size, tokenizer)
     else:
         return None
 
@@ -547,7 +551,14 @@ def test_common_shapes(
         if save_validation_info_outputs:
             cpu_validation_info.save(
                 get_validation_info_path(
-                    validation_info_dir, model_path, batch_size, seq_length, max_new_tokens, 0, ATTN_NAME, dtype=CPU_DTYPE
+                    validation_info_dir,
+                    model_path,
+                    batch_size,
+                    seq_length,
+                    max_new_tokens,
+                    0,
+                    ATTN_NAME,
+                    dtype=CPU_DTYPE,
                 )
             )
     cpu_static_tokens = cpu_validation_info.get_info("tokens")
@@ -640,7 +651,7 @@ def test_common_shapes(
                                 max_new_tokens,
                                 i,
                                 ATTN_NAME,
-                                dtype=CPU_DTYPE
+                                dtype=CPU_DTYPE,
                             )
                         )
                 cpu_static_tokens = cpu_validation_info.get_info("tokens")

--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -23,10 +23,12 @@ from aiu_fms_testing_utils.utils import (
     warmup_model,
     sample_sharegpt_requests,
 )
+from typing import Tuple
 import json
 from transformers import AutoTokenizer
 
 from aiu_fms_testing_utils.utils.aiu_setup import dprint, aiu_dist_setup
+from aiu_fms_testing_utils._version import version
 
 import os
 
@@ -245,6 +247,47 @@ common_shapes = list(
 __custom_adapter = {"architecture": "llama", "source": "fms_aiu"}
 
 
+def _strip_version_to_basic(version: str):
+    """
+    Given a version such as '0.0.2.dev497+gaca31a959.d20250825', return only 0.0.2
+    """
+    match = re.match(r"(\d+\.\d+\.\d+)", version)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def _parse_version(version: str):
+    """Parse version from a string from form *int.int.int* to Tuple[int, int, int]
+
+    Args:
+        version (str): original version of string
+
+    Returns:
+        Tuple[int,int,int]
+    """
+    major, minor, patch = _strip_version_to_basic(version).split(".")
+    return (int(major), int(minor), int(patch))
+
+
+CURRENT_AFTU_VERSION: str = ".".join([str(_) for _ in _parse_version(version)])
+
+
+def _decrement_version(version: Tuple[int, int, int]):
+    """
+    Function designed to prevent triple nested for loop while decrementing version
+    """
+    major, minor, patch = version
+    if patch > 0:
+        return (major, minor, patch - 1)
+    elif minor > 0:
+        return (major, minor - 1, 0)
+    elif major > 0:
+        return (major - 1, 0, 0)
+    else:
+        return None
+
+
 @pytest.fixture(autouse=True)
 def reset_compiler():
     yield  # run the test
@@ -363,9 +406,10 @@ def __get_validation_info_full_path(
     max_new_tokens,
     seed,
     attn_type: str,
+    aftu_version: str = CURRENT_AFTU_VERSION,
     device_type="cpu",
 ):
-    validation_file_name = f"{get_default_validation_prefix(model_path, max_new_tokens, batch_size, seq_length, 'fp16', attn_type)}.{device_type}_validation_info.{seed}.out"
+    validation_file_name = f"{get_default_validation_prefix(model_path, max_new_tokens, batch_size, seq_length, 'fp16', attn_type, aftu_version)}.{device_type}_validation_info.{seed}.out"
     full_path = os.path.join(validation_info_dir, validation_file_name)
     return full_path
 
@@ -374,25 +418,47 @@ def __load_validation_info(
     model_path, batch_size, seq_length, max_new_tokens, tokenizer, seed, attn_type: str
 ):
     # if path doesn't exist and paged isn't in the attention name, remove `attn_type` and recheck again, warn that we will no longer in the future have paths without 'attn_type'
-    full_path = __get_validation_info_full_path(
-        model_path, batch_size, seq_length, max_new_tokens, seed, attn_type
-    )
 
-    if os.path.exists(full_path):
+    aftu_version = _parse_version(version)
+    while aftu_version is not None:
+        aftu_version = _decrement_version(aftu_version)
+        if aftu_version:
+            aftu_version_str = ".".join([str(_) for _ in aftu_version])
+            full_path = __get_validation_info_full_path(
+                model_path,
+                batch_size,
+                seq_length,
+                max_new_tokens,
+                seed,
+                attn_type,
+                aftu_version_str,
+            )
+            if os.path.exists(full_path):
+                dprint(f"cpu validation info found for seed={seed} -- loading it")
+                return load_validation_information(
+                    full_path, "logits", batch_size, tokenizer
+                )
+
+    # the replace '..' with '.' comes from new full path including .<VERSION>.
+    legacy_path = __get_validation_info_full_path(
+        model_path, batch_size, seq_length, max_new_tokens, seed, attn_type, ""
+    ).replace("..", ".")
+
+    if os.path.exists(legacy_path):
         dprint(f"cpu validation info found for seed={seed} -- loading it")
-        return load_validation_information(full_path, "logits", batch_size, tokenizer)
+        return load_validation_information(legacy_path, "logits", batch_size, tokenizer)
     elif "paged" not in attn_type:
         # This regex applies to a very specific file name format
-        modified_full_path = re.sub(r"_attn-type[^.]*", "", full_path)
+        modified_legacy_path = re.sub(r"_attn-type[^.]*", "", legacy_path)
 
-        if os.path.exists(modified_full_path):
+        if os.path.exists(modified_legacy_path):
             warnings.warn(
-                f"All future paths should contain attn_type prefix information in path name, please modify {full_path=} to {modified_full_path=}",
+                f"All future paths should contain attn_type prefix information in path name, please modify {legacy_path=} to {modified_legacy_path=}",
                 stacklevel=2,
             )
             dprint(f"cpu validation info found for seed={seed} -- loading it")
             return load_validation_information(
-                modified_full_path, "logits", batch_size, tokenizer
+                modified_legacy_path, "logits", batch_size, tokenizer
             )
     return None
 

--- a/tests/testing/test_validation.py
+++ b/tests/testing/test_validation.py
@@ -11,8 +11,8 @@ from aiu_fms_testing_utils.testing.validation import (
 from aiu_fms_testing_utils._version import version_tuple
 from fms.models import get_model
 from fms.utils.generation import pad_input_ids
-import torch
 from pathlib import Path
+import torch
 
 
 @pytest.mark.parametrize(

--- a/tests/testing/test_validation.py
+++ b/tests/testing/test_validation.py
@@ -6,13 +6,14 @@ from aiu_fms_testing_utils.testing.validation import (
     extract_validation_information,
     load_validation_information,
     get_validation_info_path,
-    find_validation_info_path
+    find_validation_info_path,
 )
 from aiu_fms_testing_utils._version import version_tuple
 from fms.models import get_model
 from fms.utils.generation import pad_input_ids
 import torch
 from pathlib import Path
+
 
 @pytest.mark.parametrize(
     "validation_type,post_iteration_hook",
@@ -71,37 +72,141 @@ def test_validation_info_round_trip(validation_type, post_iteration_hook):
 
 
 def test_get_validation_info_path(tmp_path):
-    assert get_validation_info_path(tmp_path, "ibm-granite/granite-3.3-8b-instruct", 4, 64, 128, 0, "sdpa") == f"{tmp_path}/ibm-granite--granite-3.3-8b-instruct_max-new-tokens-128_batch-size-4_seq-length-64_dtype-fp16_attn-type-sdpa.{".".join([str(_) for _ in version_tuple[:3]])}.cpu_validation_info.0.out"
-    assert get_validation_info_path(tmp_path, "ibm-granite/granite-3.3-8b-instruct", 4, 64, 128, 0, "sdpa", aftu_version=(1, 2, 3)) == f"{tmp_path}/ibm-granite--granite-3.3-8b-instruct_max-new-tokens-128_batch-size-4_seq-length-64_dtype-fp16_attn-type-sdpa.1.2.3.cpu_validation_info.0.out"
+    assert (
+        get_validation_info_path(
+            tmp_path, "ibm-granite/granite-3.3-8b-instruct", 4, 64, 128, 0, "sdpa"
+        )
+        == f"{tmp_path}/ibm-granite--granite-3.3-8b-instruct_max-new-tokens-128_batch-size-4_seq-length-64_dtype-fp16_attn-type-sdpa.{'.'.join([str(_) for _ in version_tuple[:3]])}.cpu_validation_info.0.out"
+    )
+    assert (
+        get_validation_info_path(
+            tmp_path,
+            "ibm-granite/granite-3.3-8b-instruct",
+            4,
+            64,
+            128,
+            0,
+            "sdpa",
+            aftu_version=(1, 2, 3),
+        )
+        == f"{tmp_path}/ibm-granite--granite-3.3-8b-instruct_max-new-tokens-128_batch-size-4_seq-length-64_dtype-fp16_attn-type-sdpa.1.2.3.cpu_validation_info.0.out"
+    )
 
-@pytest.mark.parametrize("current_version,save_version,expected_version,version_allow_decrement", [
-    (None, version_tuple[:3], version_tuple[:3], True), # saved version is the same version as current - find
-    ((1, 1, 1), (1, 1, 2), None, True), # current version is less than any saved version -- dont find - micro
-    ((0, 0, 3), (0, 1, 2), None, True), # current version is less than any saved version -- dont find - minor
-    ((0, 2, 3), (1, 1, 2), None, True), # current version is less than any saved version -- dont find - major
-    ((1, 1, 2), (1, 1, 1), (1, 1, 1), True), # current version is greater than saved version -- find saved version - micro
-    ((1, 1, 2), (1, 1, 0), (1, 1, 0), True), # current version is greater than saved version -- find saved version - minor
-    ((1, 1, 2), (1, 0, 0), (1, 0, 0), True), # current version is greater than saved version -- find saved version - major
-    ((1, 1, 2), (1, 1, 1), None, False), # current version is greater than saved version -- dont find - micro - no decrement
-    ((1, 1, 2), (1, 1, 0), None, False), # current version is greater than saved version -- dont find - minor - no decrement
-    ((1, 1, 2), (1, 0, 0), None, False), # current version is greater than saved version -- dont find - major - no decrement
-])
-def test_find_validation_info_path(current_version, save_version, expected_version, version_allow_decrement, tmp_path):
+
+@pytest.mark.parametrize(
+    "current_version,save_version,expected_version,version_allow_decrement",
+    [
+        (
+            None,
+            version_tuple[:3],
+            version_tuple[:3],
+            True,
+        ),  # saved version is the same version as current - find
+        (
+            (1, 1, 1),
+            (1, 1, 2),
+            None,
+            True,
+        ),  # current version is less than any saved version -- dont find - micro
+        (
+            (0, 0, 3),
+            (0, 1, 2),
+            None,
+            True,
+        ),  # current version is less than any saved version -- dont find - minor
+        (
+            (0, 2, 3),
+            (1, 1, 2),
+            None,
+            True,
+        ),  # current version is less than any saved version -- dont find - major
+        (
+            (1, 1, 2),
+            (1, 1, 1),
+            (1, 1, 1),
+            True,
+        ),  # current version is greater than saved version -- find saved version - micro
+        (
+            (1, 1, 2),
+            (1, 1, 0),
+            (1, 1, 0),
+            True,
+        ),  # current version is greater than saved version -- find saved version - minor
+        (
+            (1, 1, 2),
+            (1, 0, 0),
+            (1, 0, 0),
+            True,
+        ),  # current version is greater than saved version -- find saved version - major
+        (
+            (1, 1, 2),
+            (1, 1, 1),
+            None,
+            False,
+        ),  # current version is greater than saved version -- dont find - micro - no decrement
+        (
+            (1, 1, 2),
+            (1, 1, 0),
+            None,
+            False,
+        ),  # current version is greater than saved version -- dont find - minor - no decrement
+        (
+            (1, 1, 2),
+            (1, 0, 0),
+            None,
+            False,
+        ),  # current version is greater than saved version -- dont find - major - no decrement
+    ],
+)
+def test_find_validation_info_path(
+    current_version, save_version, expected_version, version_allow_decrement, tmp_path
+):
     # create a large version path to make sure we never choose it
-    large_version_path = Path(get_validation_info_path(tmp_path, "ibm-granite/granite-3.3-8b-instruct", 4, 64, 128, 0, "sdpa", (10, 10, 10)))
+    large_version_path = Path(
+        get_validation_info_path(
+            tmp_path,
+            "ibm-granite/granite-3.3-8b-instruct",
+            4,
+            64,
+            128,
+            0,
+            "sdpa",
+            (10, 10, 10),
+        )
+    )
     large_version_path.write_text("test")
     assert large_version_path.exists()
 
-    save_path = Path(get_validation_info_path(tmp_path, "ibm-granite/granite-3.3-8b-instruct", 4, 64, 128, 0, "sdpa", save_version))
+    save_path = Path(
+        get_validation_info_path(
+            tmp_path,
+            "ibm-granite/granite-3.3-8b-instruct",
+            4,
+            64,
+            128,
+            0,
+            "sdpa",
+            save_version,
+        )
+    )
     save_path.write_text("test")
     assert save_path.exists()
 
-    found_path = find_validation_info_path(tmp_path, "ibm-granite/granite-3.3-8b-instruct", 4, 64, 128, 0, "sdpa", current_version, version_allow_decrement=version_allow_decrement)
+    found_path = find_validation_info_path(
+        tmp_path,
+        "ibm-granite/granite-3.3-8b-instruct",
+        4,
+        64,
+        128,
+        0,
+        "sdpa",
+        current_version,
+        version_allow_decrement=version_allow_decrement,
+    )
 
     if expected_version is None:
         assert found_path is None
     else:
-        match = re.search(r'(\d+)\.(\d+)\.(\d+)', found_path)
+        match = re.search(r"(\d+)\.(\d+)\.(\d+)", found_path)
         found_version = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
         assert found_version == expected_version
-


### PR DESCRIPTION
This PR builds on https://github.com/foundation-model-stack/aiu-fms-testing-utils/pull/115 and includes utilities for getting validation info paths which include version. The purpose of adding a version to the validation info is to provide a mechanism to save validation info snapshots in time as well as for uniqueness of file paths. The logic will be as follows, if the current version is greater than or equal to a saved validation logits version (largest that is less than or equal to the current version), pick up that version.