### PR TITLE
[dpp] store enforce_sizes in log name and added generic kwargs to get_default_validation_prefix

### DIFF
--- a/aiu_fms_testing_utils/testing/utils.py
+++ b/aiu_fms_testing_utils/testing/utils.py
@@ -2,6 +2,9 @@ from collections.abc import Iterable
 
 
 def format_kwargs_to_string(**kwargs):
+    """
+    Turns kwargs into a str with variable names using `-`, variables separated by `_` and iterable separated by `,`
+    """
     formatted_pairs = []
     for key, value in sorted(kwargs.items()):
         formatted_value = None

--- a/aiu_fms_testing_utils/testing/utils.py
+++ b/aiu_fms_testing_utils/testing/utils.py
@@ -1,0 +1,19 @@
+from collections.abc import Iterable
+
+
+def format_kwargs_to_string(**kwargs):
+    formatted_pairs = []
+    for key, value in sorted(kwargs.items()):
+        formatted_value = None
+        if isinstance(value, str):
+            formatted_value = value
+        elif isinstance(value, Iterable):
+            formatted_value = ",".join(map(str, value))
+        elif value:
+            formatted_value = str(value)
+        # only append if formatted_value exists
+        if formatted_value:
+            # Keep previous convention of variable names with `-` instead of `_`
+            formatted_pairs.append(f"{key.replace('_', '-')}-{formatted_value}")
+
+    return "_".join(formatted_pairs)

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -468,6 +468,7 @@ def find_validation_info_path(
     Find the validation info path if it exists, otherwise return None
     """
     enforce_sizes = kwargs.get("enforce_sizes", None)
+    sample_key = kwargs.get("sample_key", None)
 
     if aftu_version is None:
         loc_version_tuple = version_tuple[:3]
@@ -489,6 +490,7 @@ def find_validation_info_path(
             device_type,
             dtype,
             enforce_sizes=enforce_sizes,
+            sample_key=sample_key,
         )
         # if the path is found, we are done searching and can return
         if os.path.exists(full_path):

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -472,7 +472,6 @@ def find_validation_info_path(
     """
     Find the validation info path if it exists, otherwise return None
     """
-    enforce_sizes = kwargs.get("enforce_sizes", None)
     sample_key = kwargs.get("sample_key", None)
 
     if aftu_version is None:
@@ -494,7 +493,6 @@ def find_validation_info_path(
             loc_version_tuple,
             device_type,
             dtype,
-            enforce_sizes=enforce_sizes,
             sample_key=sample_key,
         )
         # if the path is found, we are done searching and can return

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -7,6 +7,8 @@ from aiu_fms_testing_utils._version import version_tuple
 import os
 from aiu_fms_testing_utils.testing.utils import format_kwargs_to_string
 
+import hashlib
+
 
 class LogitsExtractorHook(
     Callable[
@@ -146,14 +148,17 @@ def get_default_validation_prefix(
         aftu_version (str): introduced in v0.3.0 to track changed in log
 
     Returns:
-        str: A prefix that will be prepended to the file name
+        str: A hashed prefix that will be prepended to the file name
     """
     kwargs_str = format_kwargs_to_string(**kwargs)
 
     if kwargs_str == "":
-        return f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}.{aftu_version}"
+        filename = f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}"
     else:
-        return f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}_{kwargs_str}.{aftu_version}"
+        filename = f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}_{kwargs_str}"
+    hash_object = hashlib.sha256(filename.encode("utf-8"))
+    hex_digest = hash_object.hexdigest()
+    return f"{hex_digest}_{aftu_version}"
 
 
 def load_validation_information(

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -5,6 +5,7 @@ import torch
 from aiu_fms_testing_utils.utils.aiu_setup import dprint
 from aiu_fms_testing_utils._version import version_tuple
 import os
+from aiu_fms_testing_utils.testing.utils import format_kwargs_to_string
 
 
 class LogitsExtractorHook(
@@ -132,6 +133,7 @@ def get_default_validation_prefix(
     dtype: str,
     attn_type: str,
     aftu_version: str,
+    **kwargs,
 ):
     """
     Args:
@@ -146,7 +148,12 @@ def get_default_validation_prefix(
     Returns:
         str: A prefix that will be prepended to the file name
     """
-    return f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}.{aftu_version}"
+    kwargs_str = format_kwargs_to_string(**kwargs)
+
+    if kwargs_str == "":
+        return f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}.{aftu_version}"
+    else:
+        return f"{model_id.replace('/', '--')}_max-new-tokens-{max_new_tokens}_batch-size-{batch_size}_seq-length-{seq_length}_dtype-{dtype}_attn-type-{attn_type}_{kwargs_str}.{aftu_version}"
 
 
 def load_validation_information(
@@ -416,11 +423,14 @@ def get_validation_info_path(
     aftu_version: Optional[Tuple[int, int, int]] = None,
     device_type: str = "cpu",
     dtype: str = "fp16",
+    **kwargs,
 ):
     if aftu_version is None:
         aftu_version = version_tuple
 
-    validation_file_name = f"{get_default_validation_prefix(model_variant, max_new_tokens, batch_size, seq_length, dtype, attn_type, '.'.join([str(_) for _ in aftu_version[:3]]))}.{device_type}_validation_info.{seed}.out"
+    sample_key = kwargs.get("sample_key", None)
+
+    validation_file_name = f"{get_default_validation_prefix(model_variant, max_new_tokens, batch_size, seq_length, dtype, attn_type, '.'.join([str(_) for _ in aftu_version[:3]]), sample_key=sample_key)}.{device_type}_validation_info.{seed}.out"
     full_path = os.path.join(validation_info_dir, validation_file_name)
     return full_path
 
@@ -452,10 +462,12 @@ def find_validation_info_path(
     version_allow_decrement: bool = False,
     device_type: str = "cpu",
     dtype: str = "fp16",
+    **kwargs,
 ):
     """
     Find the validation info path if it exists, otherwise return None
     """
+    enforce_sizes = kwargs.get("enforce_sizes", None)
 
     if aftu_version is None:
         loc_version_tuple = version_tuple[:3]
@@ -476,6 +488,7 @@ def find_validation_info_path(
             loc_version_tuple,
             device_type,
             dtype,
+            enforce_sizes=enforce_sizes,
         )
         # if the path is found, we are done searching and can return
         if os.path.exists(full_path):

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -508,20 +508,20 @@ def sample_rag_factoid_requests(
         _cached_dataset_key=dataset_path,
     )
 
-    sample_key: str = format_kwargs_to_string(
-        dataset="rag_factoid",
-        num_requests=num_requests,
-        tokenizer=tokenizer.name_or_path.replace("/", "--"),
-        prompt_length_min=prompt_length_min,
-        prompt_length_max=prompt_length_max,
-        seed=seed,
-        enforce_heterogeneous=enforce_heterogeneous,
-        enforce_sizes=enforce_sizes,
-        truncate=truncation,
-        pad_multiple=pad_multiple,
-    )
-
     if return_key:
+        sample_key: str = format_kwargs_to_string(
+            dataset="rag_factoid",
+            num_requests=num_requests,
+            tokenizer=tokenizer.name_or_path.replace("/", "--"),
+            prompt_length_min=prompt_length_min,
+            prompt_length_max=prompt_length_max,
+            seed=seed,
+            enforce_heterogeneous=enforce_heterogeneous,
+            enforce_sizes=enforce_sizes,
+            truncate=truncation,
+            pad_multiple=pad_multiple,
+        )
+
         return sample_request, sample_key
     else:
         return sample_request
@@ -578,20 +578,19 @@ def sample_sharegpt_requests(
         _cached_dataset_key=dataset_path,
     )
 
-    sample_key: str = format_kwargs_to_string(
-        dataset="sharegpt",
-        num_requests=num_requests,
-        tokenizer=tokenizer.name_or_path.replace("/", "--"),
-        prompt_length_min=prompt_length_min,
-        prompt_length_max=prompt_length_max,
-        seed=seed,
-        enforce_heterogeneous=enforce_heterogeneous,
-        enforce_sizes=enforce_sizes,
-        truncate=truncation,
-        pad_multiple=pad_multiple,
-    )
-
     if return_key:
+        sample_key: str = format_kwargs_to_string(
+            dataset="sharegpt",
+            num_requests=num_requests,
+            tokenizer=tokenizer.name_or_path.replace("/", "--"),
+            prompt_length_min=prompt_length_min,
+            prompt_length_max=prompt_length_max,
+            seed=seed,
+            enforce_heterogeneous=enforce_heterogeneous,
+            enforce_sizes=enforce_sizes,
+            truncate=truncation,
+            pad_multiple=pad_multiple,
+        )
         return sample_request, sample_key
     else:
         return sample_request
@@ -608,6 +607,7 @@ def sample_squad_v2_qa_requests(
     enforce_sizes: List[int] | None = None,
     truncation: bool = False,
     pad_multiple: int = 64,
+    return_key: bool = False,
 ) -> List[Tuple[str, int]]:
     from datasets import load_dataset
 
@@ -621,7 +621,7 @@ def sample_squad_v2_qa_requests(
 
     ds = [f"{data['context']}\n{data['question']}" for data in ds]
 
-    return __sample_requests(
+    sample_request = __sample_requests(
         ds,
         num_requests,
         tokenizer,
@@ -633,6 +633,23 @@ def sample_squad_v2_qa_requests(
         truncation,
         pad_multiple,
     )
+
+    if return_key:
+        sample_key: str = format_kwargs_to_string(
+            dataset="squad_v2",
+            num_requests=num_requests,
+            tokenizer=tokenizer.name_or_path.replace("/", "--"),
+            prompt_length_min=prompt_length_min,
+            prompt_length_max=prompt_length_max,
+            seed=seed,
+            enforce_heterogeneous=enforce_heterogeneous,
+            enforce_sizes=enforce_sizes,
+            truncate=truncation,
+            pad_multiple=pad_multiple,
+        )
+        return sample_request, sample_key
+    else:
+        return sample_request
 
 
 def prepare_inputs(

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -11,6 +11,7 @@ import bisect
 
 from aiu_fms_testing_utils.utils.aiu_setup import dprint, rank, world_size
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+from aiu_fms_testing_utils.testing.utils import format_kwargs_to_string
 
 from fms.utils.generation import pad_input_ids
 import torch
@@ -482,6 +483,7 @@ def sample_rag_factoid_requests(
     enforce_sizes: List[int] = [],
     truncation: bool = False,
     pad_multiple: int = 64,
+    return_key: bool = False,
 ) -> List[Tuple[str, int]]:
     if not os.path.exists(dataset_path):
         print("error dataset does not exist")
@@ -492,7 +494,7 @@ def sample_rag_factoid_requests(
         for line in f:
             dataset.append(line)
 
-    return __sample_requests(
+    sample_request = __sample_requests(
         dataset,
         num_requests,
         tokenizer,
@@ -506,6 +508,24 @@ def sample_rag_factoid_requests(
         _cached_dataset_key=dataset_path,
     )
 
+    sample_key: str = format_kwargs_to_string(
+        dataset="rag_factoid",
+        num_requests=num_requests,
+        tokenizer=tokenizer.name_or_path.replace("/", "--"),
+        prompt_length_min=prompt_length_min,
+        prompt_length_max=prompt_length_max,
+        seed=seed,
+        enforce_heterogeneous=enforce_heterogeneous,
+        enforce_sizes=enforce_sizes,
+        truncate=truncation,
+        pad_multiple=pad_multiple,
+    )
+
+    if return_key:
+        return sample_request, sample_key
+    else:
+        return sample_request
+
 
 def sample_sharegpt_requests(
     dataset_path: str,
@@ -518,6 +538,7 @@ def sample_sharegpt_requests(
     enforce_sizes: List[int] | None = None,
     truncation: bool = False,
     pad_multiple: int = 64,
+    return_key: bool = False,
 ) -> List[Tuple[str, int]]:
     if not os.path.exists(dataset_path):
         print("downloading share-gpt dataset as it does not exist")
@@ -543,7 +564,7 @@ def sample_sharegpt_requests(
     dataset = [data for data in dataset if len(data["conversations"]) >= 2]
     dataset: List[str] = [data["conversations"][0]["value"] for data in dataset]
 
-    return __sample_requests(
+    sample_request = __sample_requests(
         dataset,
         num_requests,
         tokenizer,
@@ -556,6 +577,24 @@ def sample_sharegpt_requests(
         pad_multiple,
         _cached_dataset_key=dataset_path,
     )
+
+    sample_key: str = format_kwargs_to_string(
+        dataset="sharegpt",
+        num_requests=num_requests,
+        tokenizer=tokenizer.name_or_path.replace("/", "--"),
+        prompt_length_min=prompt_length_min,
+        prompt_length_max=prompt_length_max,
+        seed=seed,
+        enforce_heterogeneous=enforce_heterogeneous,
+        enforce_sizes=enforce_sizes,
+        truncate=truncation,
+        pad_multiple=pad_multiple,
+    )
+
+    if return_key:
+        return sample_request, sample_key
+    else:
+        return sample_request
 
 
 def sample_squad_v2_qa_requests(

--- a/scripts/drive_paged_programs.py
+++ b/scripts/drive_paged_programs.py
@@ -40,6 +40,7 @@ from aiu_fms_testing_utils.utils.paged import (
     get_programs_prompts,
     KVCACHE_NUM_BLOCKS_HINT,
 )
+from aiu_fms_testing_utils.testing.utils import format_kwargs_to_string
 
 parser = argparse.ArgumentParser(
     description="Script which will drive paged programs for debugging"
@@ -195,6 +196,10 @@ if args.dataset_type == "custom":
     custom_shape = (len(result), max([_[1] for _ in result]))
 
     def __custom_line_sampler(*args, **kwargs):
+        return_key = kwargs.get("return_key", False)
+        sample_key = format_kwargs_to_string(**kwargs)
+        if return_key:
+            return result, sample_key
         return result
 
     sampler = __custom_line_sampler

--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -364,7 +364,13 @@ def __filter_before_eos(metrics, filter_indexes):
 
 
 def __load_validation_info(
-    model_path, batch_size, seq_length, max_new_tokens, tokenizer, seed, attn_type: str
+    model_path,
+    batch_size,
+    seq_length,
+    max_new_tokens,
+    tokenizer,
+    seed,
+    attn_type: str,
 ):
     # if path doesn't exist and paged isn't in the attention name, remove `attn_type` and recheck again, warn that we will no longer in the future have paths without 'attn_type'
     full_path = find_validation_info_path(

--- a/tests/testing/test_validation.py
+++ b/tests/testing/test_validation.py
@@ -317,7 +317,6 @@ def test_get_default_validation_prefix(
         enforce_sizes=[],
         return_key=True,
     )
-    prefix_with_sample_key = f"{get_default_validation_prefix(model_variant, max_new_tokens, batch_size, seq_length, dtype, attn_type, '.'.join([str(_) for _ in aftu_version[:3]]), sample_key=sample_key)}.{device_type}_validation_info.{seed}.out"
 
     # Check sample key sorted by parameter name
     assert sample_key.split("_") == sorted(sample_key.split("_"))

--- a/tests/testing/test_validation.py
+++ b/tests/testing/test_validation.py
@@ -99,6 +99,20 @@ def test_get_validation_info_path(tmp_path):
         == f"{tmp_path}/ibm-granite--granite-3.3-8b-instruct_max-new-tokens-128_batch-size-4_seq-length-64_dtype-fp16_attn-type-sdpa.1.2.3.cpu_validation_info.0.out"
     )
 
+    # Check that it is accepting kwargs and handling sample_key
+    dummy_sample_key = "dataset-sharegpt_num-requests-4_pad-multiple-64_prompt-length-max-128_prompt-length-min-32_tokenizer-ibm-granite--granite-3.3-8b-Instruct"
+    assert "sample_key" and "dataset" in get_validation_info_path(
+        tmp_path,
+        "ibm-granite/granite-3.3-8b-instruct",
+        4,
+        64,
+        128,
+        0,
+        "sdpa",
+        aftu_version=(1, 2, 3),
+        sample_key=dummy_sample_key,
+    )
+
 
 @pytest.mark.parametrize(
     "current_version,save_version,expected_version,version_allow_decrement",
@@ -244,6 +258,8 @@ def test_decrement_version(max_minor, max_patch, current_version):
         + patch
         + 1
     )
+
+
 def test_format_kwargs_to_string():
     kwargs = {
         "enforce_sizes": [1, 32, 4, 8],


### PR DESCRIPTION
- added new function `format_kwargs_to_string` for easier conversion of kwargs into string
- introduced kwargs to get_default_validation_prefix in case future variables needs to be added to function
- used additional enforce_sizes variable in dpp in `get_validation_info_path` to get string with enforce_sizes in log name
- added return_keys to samplers such as sample_rag_factoid_requests and sample_sharegpt_requests, default value False, this allows the returning of a sample_key(str) which contains the exact values used
- in dpp changed sampler inside __prepare_inputs to use return_key True, returning a sample_key which is then used when storing the log name