### PR TITLE
Add ability in DPP script to select one or many programs that satisfy min batch and min sequence requirements

### DIFF
--- a/scripts/drive_paged_programs.py
+++ b/scripts/drive_paged_programs.py
@@ -416,16 +416,15 @@ for program_id, min_batch_size, min_prompt_length in programs:
     found_valid_prompt = False
     filtered_program_map = program_map
     if program_id.isnumeric():
-        program_id = int(program_id)
         filtered_program_map = {
             k: v
             for k, v in program_map.items()
-            if k[0] == program_criteria_list[program_id]
+            if k[0] == program_criteria_list[int(program_id)]
         }
 
-    used_keys = {}
+    used_keys = set()
     # for each program, we need to check if we have a shape that satisfies the --programs request
-    for program_seq_key, valid_prompt_shapes in program_map.items():
+    for program_seq_key, valid_prompt_shapes in filtered_program_map.items():
         # if ? or numeric => we need to check if we have found at least one valid key to stop
         if (program_id == "?" or program_id.isnumeric()) and len(used_keys) > 0:
             break


### PR DESCRIPTION
In many cases, a user may want to run a specific sequence length or batch size, but they don't know exactly which program id would be used for these specifications. This feature will allow a user to enter the following.

<program_id>:<min_batch>,<min_seq> where program_id can be one of:

`int` - exact program id (This is the current case)
`?` - any program that satisfies the requirements
`*` - all programs that satisfies the requirements