### PR TITLE
numa support for inference.py

### DIFF
--- a/aiu_fms_testing_utils/scripts/inference.py
+++ b/aiu_fms_testing_utils/scripts/inference.py
@@ -343,6 +343,8 @@ if args.distributed:
             numa_rank = dist.get_rank()
             numa_node = dist.get_rank() // numa_size_per_node
             schedule.run_on_nodes(numa_node)
+            from numa import memory
+            memory.set_local_alloc()
             dprint(f"NUMA: process {numa_rank} set to node {numa_node}")
         except:
             dprint(f"NUMA not available in this machine, please install libnuma libraries")


### PR DESCRIPTION
This is an optional numa support (activated with the --numa flag) for NUMA node awareness.
Thus far experiments have shown that NUMA awareness leads to more stable and lower times with multi-aiu:

https://github.ibm.com/ai-foundation/aiu-app-sw-tracker/issues/1323

cc: @JRosenkranz @ani300 