### PR TITLE
Extend transformers support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 "fms-model-optimizer[fp8]>=0.5.0,<1.0",
 "sentencepiece>=0.2.0,<0.3.0",
 "numpy>=1.26.4,<2.3.0",
-"transformers>=4.45,<=4.55.2",
+"transformers>=4.45,<=4.58",
 "torch==2.7.1",
 ]
 


### PR DESCRIPTION
vllm now requires transformers >= 4.56, so this prevents us from upgrading. AFTU is only a dev dependency of vllm-spyre so this doesn't technically block release, but it does prevent us from cleanly installing our test dependencies without downgrading vllm which we obviously don't want to do.