### PR TITLE
fix for #164 paged.py get head_size from model.config head_dim when defined

### DIFF
--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -159,7 +159,9 @@ def generate(
         raise ValueError("model must have a distributed_strategy")
 
     kvheads = kvheads // tensor_parallel_size if kvheads > 1 else kvheads
-    head_size = model.config.emb_dim // nheads
+    head_size = getattr(
+        model.config, "head_dim", model.config.emb_dim // model.config.nheads
+    )
     if "fp8" in kwargs["attn_name"]:
         from fms_mo.aiu_addons.fp8.fp8_utils import ScaledTensor
 


### PR DESCRIPTION
This is a minor PR that fixes issue #164, which makes the paged.py get head_size from model.config head_dim when defined