### PR TITLE
upgrade pytorch dep range - release 1.1 only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 "sentencepiece>=0.2.0,<0.3.0",
 "numpy>=1.26.4,<2.3.0",
 "transformers>=4.45,<=4.58",
-"torch==2.7.1",
+"torch>=2.7.1,<2.10.0",
 ]
 
 # This section installs command line executables that point to specific scripts


### PR DESCRIPTION
This PR loosens the requirements around PyTorch to allow Torch 2.9. We are upgrading to 2.9 for release 1.1 in AIU SW stack

We have run tests with Torch 2.9 in our AIU SW stack , as part of issue in internal tracker