### PR TITLE
Refactor get valid prompts - for memory optimization

### DIFF
--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -518,6 +518,7 @@ program_map = get_programs_prompts(
 for v in program_map.values():
     random.Random(42).shuffle(v)
 
+
 # select prompts that fit the batch size criteria
 def get_program_prompt_list():
     if custom_shape:


### PR DESCRIPTION
Currently on main, we generate all valid prompts for all programs in a large list called `valid_prompts`. After which, we start validating programs using the list of prompts. This can cause large memory consumption if size of prompts is large. We were running into out of memory with 128k size prompts.

This PR makes the generation of prompts a iterator instead. Prompts will be generated for a program and the program will be validated, before going to the next program. If prompts could not be generated for a program, the program validation is skipped just like today. 

This helps save a lot of memory. Users will see change that prompt extraction for all programs will not happen upfront, and will happen as needed for a program

**How PR was tested:**
1. Tested by running entire run with existing datasets. LOg attached 
[refactor_metrics_test.txt](https://github.com/user-attachments/files/24601834/refactor_metrics_test.txt) . The only change is that instead of extracting prompts upfront, prompts are extracted per program 
2. I also tested custom prompts to ensure there was no code crash and it worked as expected
