### PR TITLE
Fix IndexError: list index out of range when no prompt is found

### DIFF
--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -288,6 +288,8 @@ def __prepare_inputs(batch_size, seq_length, tokenizer, enforce_sizes=[], seed=0
             encoded = encoded[:seq_length]
         prompt_list.append(encoded)
 
+    if not prompt_list:
+        raise ValueError(f"No valid prompt sample exists in dataset for input shape (Batch Size={batch_size}, Seq Length={seq_length})")
     if len(prompt_list) < batch_size:
         dprint(
             f"You requested {batch_size} prompts but we were only able to get {len(prompt_list)} valid prompts. We will be repeating the first prompt."

--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -289,7 +289,9 @@ def __prepare_inputs(batch_size, seq_length, tokenizer, enforce_sizes=[], seed=0
         prompt_list.append(encoded)
 
     if not prompt_list:
-        raise ValueError(f"No valid prompt sample exists in dataset for input shape (Batch Size={batch_size}, Seq Length={seq_length})")
+        raise ValueError(
+            f"No valid prompt sample exists in dataset for input shape (Batch Size={batch_size}, Seq Length={seq_length})"
+        )
     if len(prompt_list) < batch_size:
         dprint(
             f"You requested {batch_size} prompts but we were only able to get {len(prompt_list)} valid prompts. We will be repeating the first prompt."


### PR DESCRIPTION
Error also seen when DPP is run for FP16 Granite model using RAG `--programs *:0,>=8192` to test chunked prefill feature. 
From @Ssukriti 's knowledge transfer got to know that the issue occurs when [prompt_list in __prepare_input function](https://github.com/Abhishek-TAMU/aiu-fms-testing-utils/blob/685261d306ce030e62e94f8c07f274e6f8c57744/aiu_fms_testing_utils/scripts/drive_paged_programs.py#L293) is empty for any shape. Hence [Value error is raised](https://github.com/Abhishek-TAMU/aiu-fms-testing-utils/blob/685261d306ce030e62e94f8c07f274e6f8c57744/aiu_fms_testing_utils/scripts/drive_paged_programs.py#L292) to trigger [this](https://github.com/Abhishek-TAMU/aiu-fms-testing-utils/blob/685261d306ce030e62e94f8c07f274e6f8c57744/aiu_fms_testing_utils/scripts/drive_paged_programs.py#L616) and continue finding the prompt for that program. 

It successfully runs all 14 programs.

cc: @JRosenkranz 