### PR TITLE
Add support for compile only backend.

### DIFF
--- a/aiu_fms_testing_utils/scripts/inference.py
+++ b/aiu_fms_testing_utils/scripts/inference.py
@@ -394,7 +394,7 @@ elif is_aiu_backend:
             print("must set AIU_WORLD_RANK_0")
             exit()
         os.environ.setdefault("FLEX_COMPUTE", "SENTIENT")
-        if args.compile_backend_aiu == "compile_only_backend":
+        if args.compile_backend_aiu == "sendnn_compile_only":
             os.environ.setdefault("FLEX_DEVICE", "COMPILE")
         else:
             os.environ.setdefault("FLEX_DEVICE", "PF")

--- a/aiu_fms_testing_utils/scripts/inference.py
+++ b/aiu_fms_testing_utils/scripts/inference.py
@@ -607,7 +607,8 @@ if args.compile:
     fx_config.backed_size_oblivious = "paged" in attn_name
     if is_aiu_backend:
         model.compile(
-            backend=args.compile_backend_aiu, options={"sendnn.dynamic": args.compile_dynamic_sendnn}
+            backend=args.compile_backend_aiu,
+            options={"sendnn.dynamic": args.compile_dynamic_sendnn},
         )
     else:
         # compiling can make first inference pass slow


### PR DESCRIPTION
Adds support for a new backend to allow running AIU software stack (compilation, caching) on CPU for systems without AIUs. Precompiled cache would be compatible with AIUs. 


Adds a new flag --compile_backend_aiu. Default is "sendnn" to match previous behavior. Set to "sendnn_compile_only" to use new backend.