### PR TITLE
Fix Missing Import

### DIFF
--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -4,6 +4,7 @@ import random
 import time
 from typing import Any, Callable, List, MutableMapping, Optional, Tuple, Union
 import torch
+import torch.nn.functional as F
 import fms.utils.spyre.paged  # noqa
 from aiu_fms_testing_utils.utils import get_pad_size
 


### PR DESCRIPTION
I noticed that the torch functional API is used when sampling is enabled in paged attention, but not imported - probably from copying from FMS and tweaking the generate implementation.

Adds it to prevent import errors if sampling is turned off.