### PR TITLE
[WIP] MM paged generate

### DIFF
--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -11,6 +11,7 @@ from itertools import dropwhile
 import re
 from typing import Any, Dict, Iterable, List, Literal, NamedTuple, Optional, Tuple
 
+from scripts.inference import is_multimodal
 import torch
 from fms.models import get_model
 from fms.utils.generation import pad_input_ids
@@ -39,6 +40,7 @@ from aiu_fms_testing_utils.utils import (
     warmup_model,
 )
 from aiu_fms_testing_utils.utils.aiu_setup import aiu_dist_setup, dprint, local_rank
+from aiu_fms_testing_utils.utils.model_setup import requires_embedding_inputs
 from aiu_fms_testing_utils.utils.paged import (
     ProgramCriteria,
     get_programs_prompts,
@@ -1428,6 +1430,9 @@ def main() -> None:
             model_config=model_config,
         )
 
+    # Check if model is multi-modal
+    is_multimodal = requires_embedding_inputs(model.config)
+
     # Model Warmup
     ## warmup with any input so compiler produces criteria json
     ## TODO: Swap this with _prepare_inputs once fix for shape_id is available
@@ -1447,6 +1452,7 @@ def main() -> None:
         compile_dynamic_sendnn=True,
         stagger_update_lazyhandle=args.stagger_update_lazyhandle,
         prefill_chunk_size=args.prefill_chunk_size,
+        is_multimodal=is_multimodal,
         **extra_kwargs,
     )
     if args.distributed:

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -55,6 +55,7 @@ def warmup_model(
     use_cache: bool = True,
     stagger_update_lazyhandle: int = 0,
     prefill_chunk_size: int = 0,
+    is_multimodal=False,
     **extra_kwargs,
 ):
     import torch_sendnn
@@ -90,6 +91,11 @@ def warmup_model(
             )
 
     extra_kwargs = {**_extra_kwargs, "last_n_tokens": 64 if "paged" in attn_name else 1}
+
+    if is_multimodal and hasattr(model, "prepare_inputs_for_generation"):
+        attention_specific_kwargs["prepare_model_inputs_hook"] = (
+            model.prepare_inputs_for_generation
+        )
 
     with stagger_region(stagger_update_lazyhandle):
         with torch_sendnn.warmup_mode():

--- a/aiu_fms_testing_utils/utils/model_setup.py
+++ b/aiu_fms_testing_utils/utils/model_setup.py
@@ -169,3 +169,8 @@ def print_model_params(model: nn.Module, args: argparse.Namespace) -> None:
         )
     dprint(model)
     dprint("=" * 60 + "\n")
+
+
+def requires_embedding_inputs(model_config):
+    """Determine if we should use embeddings as inputs (currently only multimodal)."""
+    return hasattr(model_config, "text_config")

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -10,6 +10,7 @@ from aiu_fms_testing_utils.utils import get_pad_size
 
 logger = logging.getLogger(__name__)
 
+
 def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
     """
     Adjusts the inputs to a batch. Batch size 1 cannot be handled since we want a symbolic shape for the batch
@@ -28,9 +29,11 @@ def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
         kwargs["position_ids"] = position_ids[0].repeat(2, 1)
     return input_ids, kwargs
 
+
 def _requires_embedding_inputs(model_config):
     """Determine if we should use embeddings as inputs (currently only multimodal)."""
     return hasattr(model_config, "text_config")
+
 
 def _get_text_config(model_config):
     """Extract the text config from the model; if it's multimodal, all settings
@@ -38,8 +41,9 @@ def _get_text_config(model_config):
     if text_config := getattr(model_config, "text_config", None):
         logger.info("This model is multimodal - using the text subconfig!")
         return text_config
-    return model_config    
-    
+    return model_config
+
+
 def _infer_model_dtype(model):
     """Try to infer the dtype from the model."""
 
@@ -48,7 +52,7 @@ def _infer_model_dtype(model):
     if len(types_set) == 1:
         model_dtype = types_set.pop()
         return model_dtype
-    
+
     # FIXME - this is super hacky, but leaving it to
     # match existing behavior to avoid changing it in
     # multimodal support PR.
@@ -61,6 +65,7 @@ def _infer_model_dtype(model):
         logger.warning("Unable to infer model weight type")
         model_dtype = torch.float32
     return model_dtype
+
 
 def _infer_kv_heads(text_config):
     """Given the model config, or text config (in multimodal case), determine the number
@@ -329,8 +334,11 @@ def generate(
         if prepare_model_inputs_hook is not None:
             input_ids, kwargs = prepare_model_inputs_hook(i, input_ids, kwargs)
             if is_multimodal and input_ids.ndim != 3:
-                logger.warning("The model is multimodal, but iteration %s's prepare hook did not yield 3D embeddings (typically shape [bsz, seq_len, emb_dim], got %s)", i, list(input_ids.shape))
-
+                logger.warning(
+                    "The model is multimodal, but iteration %s's prepare hook did not yield 3D embeddings (typically shape [bsz, seq_len, emb_dim], got %s)",
+                    i,
+                    list(input_ids.shape),
+                )
 
         # prefill
         if i == 0:
@@ -502,7 +510,6 @@ def generate(
                         # if we have it.
                         if input_ids_seq_chunk.ndim == 3:
                             torch._dynamo.mark_static(input_ids_seq_chunk, 2)
-
 
                         # seq dynamic
                         torch._dynamo.mark_dynamic(input_ids_seq_chunk, 1)

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, MutableMapping, Optional, Tuple, Union
 import torch
 import fms.utils.spyre.paged  # noqa
 from aiu_fms_testing_utils.utils import get_pad_size
+from aiu_fms_testing_utils.utils.model_setup import requires_embedding_inputs
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +29,6 @@ def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
     if position_ids is not None:
         kwargs["position_ids"] = position_ids[0].repeat(2, 1)
     return input_ids, kwargs
-
-
-def _requires_embedding_inputs(model_config):
-    """Determine if we should use embeddings as inputs (currently only multimodal)."""
-    return hasattr(model_config, "text_config")
 
 
 def _get_text_config(model_config):
@@ -177,7 +173,7 @@ def generate(
     )
 
     ### Multimodal related
-    is_multimodal = _requires_embedding_inputs(model.config)
+    is_multimodal = requires_embedding_inputs(model.config)
     text_config = _get_text_config(model.config)
     if is_multimodal and prepare_model_inputs_hook is None:
         # Best effort warning about what to pass for the post iteration hook;


### PR DESCRIPTION
This is the first pass at enabling multimodal inputs for paged attention generate.

FYI @tharapalanivel @flaviabeo @gkumbhat - please feel free to use this draft PR as a starting point for looking into this if you like.

The main changes are:
- Uses embedding inputs for multimodal models
- If it's multimodal (i.e., has a text_config as a subconfig), pull opts from the text_config
- If all named params are the same dtype, use that dtype for the kv cache (otherwise falls back to existing behavior)
    - The existing fallback to float32 is pretty dangerous - with the above change, hopefully this should not really occur (assuming weights are mostly homogeneous for a given model). We should really not assume a default dtype for the model, since mismatches will break at decode time
- Started to pull some of the hackery around figuring out things like kv heads etc into small helpers to be a bit more clear
- Allow passing a `prepare_model_inputs_hook` to run multimodal models' `prepare_inputs_for_generation` to get the merged mm/text embeddings.
- If we have `input_ids` that are 3D, the final dimension is marked as static for compile since it's the embedding dim. When this is eventually consolidated with generate in FMS ([ref](https://github.com/foundation-model-stack/foundation-model-stack/blob/v1.6.0/fms/utils/generation.py#L274)) it would be better to be better about variable names, but for now it's keeping the same naming convention as FMS intentionally, since most of this code is based on generate there.

Current state & next steps:
- On eager backend, I was able to run granite vision and get a coherent output
- On AIU, outputs seem more erratic; it's also possible this is due to issues in granite vision though, because eager / AIU outputs on granite vision don't match at the moment, and there are quality issues that still need to be fixed there (just did a quick spot check).
- Chunked prefill is not finished - you can enable it by passing`prefill_chunk_size`; currently things break because padding is added afterward as needed, a bit later in the iteration. We need to refactor to do the padding before calling the pre iteration hook so that the created embeddings are correctly padded (i.e., we do *not* want to just extend the zeros IDs to 2D to concat onto the embeddings to fix the shape error).


For testing, here is a script that you can use to get started as well:
```python
### Minimal example of paged attention with multimodal inputs

import os
os.environ["VLLM_DT_MAX_BATCH_SIZE"] = "1"
os.environ["VLLM_DT_MAX_CONTEXT_LEN"] = "8192"
os.environ.setdefault("COMPILATION_MODE", "offline_decoder")

# Third Party
from fms.models import get_model
from fms.utils import serialization
from fms.utils.generation import pad_input_ids
from aiu_fms_testing_utils.utils.paged import generate
from PIL import Image
from fms.utils.spyre import paged
from transformers import LlavaNextProcessor
import requests
import torch
import torch_sendnn

def _get_inputs(processor):
    url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg"
    image = Image.open(requests.get(url, stream=True).raw)
    inputs = "<|system|>\nA chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.\n<|user|>\n<image>\nAnswer succinctly. What animal is shown in this image?\n<|assistant|>\n"
    inputs = processor(text=inputs, images=image, return_tensors="pt")
    return inputs

def infer(model, input_ids, max_new_tokens, inputs):
    with torch_sendnn.warmup_mode():
        return generate(
            model,
            input_ids,
            max_new_tokens=max_new_tokens,
            use_cache=True,
            do_sample=False,
            extra_kwargs=inputs,
            eos_token_id=0, # https://huggingface.co/ibm-granite/granite-vision-3.3-2b/blob/main/config.json#L129
            prepare_model_inputs_hook=model.prepare_inputs_for_generation,
            # prefill_chunk_size=128 # FIXME - you can test chunked prefill with this, but need to correctly handle the extra pads
        )

if __name__ == "__main__":
    max_new_tokens = 3
    min_pad_length = 4992
        
    model_path = "ibm-granite/granite-vision-3.3-2b"

    processor = LlavaNextProcessor.from_pretrained(model_path)
    inputs = _get_inputs(processor)

    input_ids = inputs["input_ids"]
    inputs.pop("input_ids")
    input_ids, padding_kwargs = pad_input_ids(input_ids, min_pad_length=min_pad_length)
    inputs["mask"] = padding_kwargs["mask"]
    inputs["position_ids"] = padding_kwargs["position_ids"]

    inputs["only_last_token"] = True
    inputs["attn_name"] = "spyre_paged_attn"
    
    # head_dim expansion required for granite vision
    serialization.extend_adapter(
        "llava_next", "hf", ["weight_expansion_for_mismatched_head_dim"]
    )
    config_dict = {"head_dim": 128}

    # Load & Compile (ensure to add compile for sendnn backend)
    print("getting the model")
    model = get_model(
        "hf_pretrained",
        model_path,
        override_hf_pretrained_config=True,
        text_config=config_dict,
        data_type=torch.float32,
        fused_weights=False, # Needed for granite vision I think - True case seems to be broken in FMS...
    )

    model.eval()
    torch.set_grad_enabled(False)
    # model.compile(backend="sendnn")

    # Warmup on AIU
    # infer(model, input_ids, max_new_tokens, inputs)

    output = infer(model, input_ids, max_new_tokens, inputs)

    if len(output.shape) == 1:
        output = output.unsqueeze(0)

    for i in range(output.shape[0]):
        print(processor.decode(output[i], skip_special_tokens=True))
```

Example output on CPU:
```
<|system|>
A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.
<|user|>

Answer succinctly. What animal is shown in this image?
<|assistant|>
cat.
```