### PR TITLE
[DPP][Fix] Add missing used_keys.add()

### DIFF
--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -871,6 +871,7 @@ def get_valid_prompts(
                                 allow_truncation=allow_truncation,
                                 enforce_sizes=enforce_sizes,
                             )
+                            used_keys.add(program_seq_key[0])
                             yield ValidPrompt(
                                 program_id=program_seq_key[0],
                                 shape=valid_prompt_shape,


### PR DESCRIPTION
Fixes a regression where `used_keys` remains empty even when a valid prompt is found, causing the warning message `"no valid prompt shape was found..."` regardless of whether one was found.