### PR TITLE
Mm paged generate

### DIFF
--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -11,6 +11,7 @@ from itertools import dropwhile
 import re
 from typing import Any, Dict, Iterable, List, Literal, NamedTuple, Optional, Tuple
 
+from scripts.inference import is_multimodal
 import torch
 from fms.models import get_model
 from fms.utils.generation import pad_input_ids
@@ -39,6 +40,7 @@ from aiu_fms_testing_utils.utils import (
     warmup_model,
 )
 from aiu_fms_testing_utils.utils.aiu_setup import aiu_dist_setup, dprint, local_rank
+from aiu_fms_testing_utils.utils.model_setup import requires_embedding_inputs
 from aiu_fms_testing_utils.utils.paged import (
     ProgramCriteria,
     get_programs_prompts,
@@ -1428,6 +1430,9 @@ def main() -> None:
             model_config=model_config,
         )
 
+    # Check if model is multi-modal
+    is_multimodal = requires_embedding_inputs(model.config)
+
     # Model Warmup
     ## warmup with any input so compiler produces criteria json
     ## TODO: Swap this with _prepare_inputs once fix for shape_id is available
@@ -1447,6 +1452,7 @@ def main() -> None:
         compile_dynamic_sendnn=True,
         stagger_update_lazyhandle=args.stagger_update_lazyhandle,
         prefill_chunk_size=args.prefill_chunk_size,
+        is_multimodal=is_multimodal,
         **extra_kwargs,
     )
     if args.distributed:

--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -11,7 +11,6 @@ from itertools import dropwhile
 import re
 from typing import Any, Dict, Iterable, List, Literal, NamedTuple, Optional, Tuple
 
-from scripts.inference import is_multimodal
 import torch
 from fms.models import get_model
 from fms.utils.generation import pad_input_ids

--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -176,6 +176,12 @@ def parse_cli_args() -> argparse.Namespace:
         help="The model id or path to use for this test. Note: must be a huggingface format",
     )
     parser.add_argument(
+        "--tokenizer",
+        type=str,
+        default=None,
+        help="The tokenizer id or path to use. If not specified, will use the model_variant. Useful for models without their own tokenizer (e.g., Mistral-3)",
+    )
+    parser.add_argument(
         "--timing",
         type=str,
         choices=["e2e", "per-token"],
@@ -1416,26 +1422,15 @@ def main() -> None:
         program_criteria_json_path=args.program_criteria_json_path,
         attention_type=args.attention_type,
     )
-    # Load tokenizer with Mistral-3 fallback support
-    try:
-        tokenizer = AutoTokenizer.from_pretrained(args.model_variant)
-    except KeyError as err:
-        transformers_config = AutoConfig.from_pretrained(args.model_variant)
-        if transformers_config.model_type == "mistral3":
-            # NOTE: mistral-small-3.2 doesn't come with its own tokenizer
-            # so here we rely on 3.1's tokenizer
-            # NOTE: the reason we are not using mistral tokenizer from mistral_common is to:
-            # 1. Rest of the script assumes tokenizer to be HF and have properties like `bos_token`
-            # 2. Avoid bunch of extra dependencies
-            warnings.warn("""
-                Unable to fetch mistral model, using Mistral-Small-3.1 manually. If different one required,
-                please configure it manually via args.tokenizer
-            """)
-            tokenizer = AutoTokenizer.from_pretrained(
-                "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
-            )
-        else:
-            raise err
+    # Load tokenizer - use args.tokenizer if provided, otherwise use model_variant
+    tokenizer_path = args.tokenizer if args.tokenizer is not None else args.model_variant
+    
+    # Auto-detect Mistral tokenizers and apply regex fix
+    tokenizer_kwargs = {}
+    if "mistral" in tokenizer_path.lower():
+        tokenizer_kwargs["fix_mistral_regex"] = True
+    
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, **tokenizer_kwargs)
 
     sampler, allow_truncation, custom_shape = get_sampler(
         dataset_type=args.dataset_type,

--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -9,6 +9,7 @@ import random
 import time
 from itertools import dropwhile
 import re
+import warnings
 from typing import Any, Dict, Iterable, List, Literal, NamedTuple, Optional, Tuple
 
 import torch
@@ -16,7 +17,7 @@ from fms.models import get_model
 from fms.utils.generation import pad_input_ids
 from torch import distributed as dist
 from torch.fx.experimental import _config as fx_config
-from transformers import AutoTokenizer
+from transformers import AutoConfig, AutoTokenizer
 from aiu_fms_testing_utils.utils.dpp_config import DPPRunnerConfig
 from aiu_fms_testing_utils.utils.env_utils import scoped_environ
 from aiu_fms_testing_utils.testing.validation import (
@@ -908,6 +909,7 @@ def generate_cpu_validation(
     attn_name: str,
     cpu_dtype: str,
     tokenizer: AutoTokenizer,
+    is_multimodal: bool = False,
 ) -> ValidationInfo:
     """Generates or loads CPU validation information for reference comparison.
 
@@ -928,6 +930,7 @@ def generate_cpu_validation(
         attn_name: Name of the attention algorithm used.
         cpu_dtype: Data type string for CPU validation ("fp8" or "fp32").
         tokenizer: HuggingFace tokenizer for the model.
+        is_multimodal: Whether the model is multimodal (requires embedding inputs).
 
     Returns:
         ValidationInfo: ValidationInfo object containing CPU reference outputs
@@ -947,6 +950,11 @@ def generate_cpu_validation(
         sample_key=sample_key,
     )
     if cpu_validation_info is None:
+        # Set up multimodal hook if needed
+        prepare_model_inputs_hook = None
+        if is_multimodal and hasattr(validation_model, "prepare_inputs_for_generation"):
+            prepare_model_inputs_hook = validation_model.prepare_inputs_for_generation
+
         cpu_validation_info = extract_validation_information(
             model=validation_model,
             input_ids=input_ids,
@@ -954,6 +962,7 @@ def generate_cpu_validation(
             post_iteration_hook=LogitsExtractorHook(),
             attn_algorithm="math",
             pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None,
+            prepare_model_inputs_hook=prepare_model_inputs_hook,
             **extra_kwargs,
         )
         if save_validation_info_outputs:
@@ -984,6 +993,7 @@ def generate_aiu_validation(
     cpu_validation_info: Optional[ValidationInfo],
     extra_kwargs: Dict[str, Any],
     pad_token_id: Optional[int] = None,
+    is_multimodal: bool = False,
 ) -> ValidationInfo:
     """Generates AIU validation information by running inference on the compiled model.
 
@@ -1001,6 +1011,7 @@ def generate_aiu_validation(
         cpu_validation_info: Optional CPU validation data for golden token injection.
         extra_kwargs: Dictionary with attention mask and other model inputs.
         pad_token_id: Optional padding token ID for the tokenizer.
+        is_multimodal: Whether the model is multimodal (requires embedding inputs).
 
     Returns:
         ValidationInfo: ValidationInfo object containing AIU outputs (tokens, logits,
@@ -1009,6 +1020,11 @@ def generate_aiu_validation(
     golden_hook = None
     if test_type == "metrics" and cpu_validation_info:
         golden_hook = GoldenTokenHook(cpu_validation_info.get_info("tokens"))
+
+    # Set up multimodal hook if needed
+    prepare_model_inputs_hook = None
+    if is_multimodal and hasattr(model, "prepare_inputs_for_generation"):
+        prepare_model_inputs_hook = model.prepare_inputs_for_generation
 
     aiu_validation_info = extract_validation_information(
         model=model,
@@ -1019,6 +1035,7 @@ def generate_aiu_validation(
         timing=timing,
         prefill_chunk_size=prefill_chunk_size,
         pad_token_id=pad_token_id,
+        prepare_model_inputs_hook=prepare_model_inputs_hook,
         **extra_kwargs,
     )
 
@@ -1259,6 +1276,7 @@ def generate_validation_info_and_test(
     timing: str,
     prefill_chunk_size: int,
     model_variant: str,
+    is_multimodal: bool = False,
 ) -> list[Any]:
     """Generates tokens using AIU and CPU models and validates the results.
 
@@ -1294,6 +1312,7 @@ def generate_validation_info_and_test(
                 attn_name=env_config.attn_name,
                 cpu_dtype=env_config.cpu_dtype,
                 tokenizer=tokenizer,
+                is_multimodal=is_multimodal,
             )
 
             aiu_validation_info = generate_aiu_validation(
@@ -1306,6 +1325,7 @@ def generate_validation_info_and_test(
                 cpu_validation_info=cpu_validation_info,
                 extra_kwargs=valid_prompt.extra_kwargs,
                 pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None,
+                is_multimodal=is_multimodal,
             )
 
             if test_type == "metrics":
@@ -1344,6 +1364,7 @@ def generate_validation_info_and_test(
                 cpu_validation_info=None,
                 extra_kwargs=valid_prompt.extra_kwargs,
                 pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None,
+                is_multimodal=is_multimodal,
             )
 
             if local_rank == 0:
@@ -1395,7 +1416,27 @@ def main() -> None:
         program_criteria_json_path=args.program_criteria_json_path,
         attention_type=args.attention_type,
     )
-    tokenizer = AutoTokenizer.from_pretrained(args.model_variant)
+    # Load tokenizer with Mistral-3 fallback support
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(args.model_variant)
+    except KeyError as err:
+        transformers_config = AutoConfig.from_pretrained(args.model_variant)
+        if transformers_config.model_type == "mistral3":
+            # NOTE: mistral-small-3.2 doesn't come with its own tokenizer
+            # so here we rely on 3.1's tokenizer
+            # NOTE: the reason we are not using mistral tokenizer from mistral_common is to:
+            # 1. Rest of the script assumes tokenizer to be HF and have properties like `bos_token`
+            # 2. Avoid bunch of extra dependencies
+            warnings.warn("""
+                Unable to fetch mistral model, using Mistral-Small-3.1 manually. If different one required,
+                please configure it manually via args.tokenizer
+            """)
+            tokenizer = AutoTokenizer.from_pretrained(
+                "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+            )
+        else:
+            raise err
+
     sampler, allow_truncation, custom_shape = get_sampler(
         dataset_type=args.dataset_type,
         dataset_path=args.dataset_path,
@@ -1504,6 +1545,7 @@ def main() -> None:
         timing=args.timing,
         prefill_chunk_size=args.prefill_chunk_size,
         model_variant=args.model_variant,
+        is_multimodal=is_multimodal,
     )
 
     if not args.skip_validation and local_rank == 0:

--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -349,7 +349,11 @@ def _prepare_inputs(
         )
         prompt_list = [prompt_list[0]] * (batch_size - len(prompt_list)) + prompt_list
 
-    input_ids, extra_kwargs = pad_input_ids(prompt_list, min_pad_length=seq_length)
+    input_ids, extra_kwargs = pad_input_ids(
+        prompt_list,
+        min_pad_length=seq_length,
+        pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None
+    )
     extra_kwargs["mask"] = extra_kwargs["mask"].to(torch.float16)
 
     return PreparedInputs(
@@ -949,6 +953,7 @@ def generate_cpu_validation(
             max_new_tokens=max_new_tokens,
             post_iteration_hook=LogitsExtractorHook(),
             attn_algorithm="math",
+            pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None,
             **extra_kwargs,
         )
         if save_validation_info_outputs:
@@ -978,6 +983,7 @@ def generate_aiu_validation(
     input_ids: torch.Tensor,
     cpu_validation_info: Optional[ValidationInfo],
     extra_kwargs: Dict[str, Any],
+    pad_token_id: Optional[int] = None,
 ) -> ValidationInfo:
     """Generates AIU validation information by running inference on the compiled model.
 
@@ -994,6 +1000,7 @@ def generate_aiu_validation(
         input_ids: Tokenized input tensor.
         cpu_validation_info: Optional CPU validation data for golden token injection.
         extra_kwargs: Dictionary with attention mask and other model inputs.
+        pad_token_id: Optional padding token ID for the tokenizer.
 
     Returns:
         ValidationInfo: ValidationInfo object containing AIU outputs (tokens, logits,
@@ -1011,6 +1018,7 @@ def generate_aiu_validation(
         last_n_tokens=64,
         timing=timing,
         prefill_chunk_size=prefill_chunk_size,
+        pad_token_id=pad_token_id,
         **extra_kwargs,
     )
 
@@ -1297,6 +1305,7 @@ def generate_validation_info_and_test(
                 input_ids=valid_prompt.input_ids,
                 cpu_validation_info=cpu_validation_info,
                 extra_kwargs=valid_prompt.extra_kwargs,
+                pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None,
             )
 
             if test_type == "metrics":
@@ -1334,6 +1343,7 @@ def generate_validation_info_and_test(
                 input_ids=valid_prompt.input_ids,
                 cpu_validation_info=None,
                 extra_kwargs=valid_prompt.extra_kwargs,
+                pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None,
             )
 
             if local_rank == 0:

--- a/aiu_fms_testing_utils/scripts/inference.py
+++ b/aiu_fms_testing_utils/scripts/inference.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import random
 import time
+import warnings
 
 # Third Party
 from aiu_fms_testing_utils.utils import aiu_setup, warmup_model, stagger_region
@@ -22,7 +23,7 @@ from fms.models.llama import LLaMAConfig, _llama_factory_factory
 from fms.utils import generation
 from fms.utils.generation import pad_input_ids
 
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, AutoConfig
 
 
 # This example script validates the LLaMA implementation by running inference on a couple of prompts.
@@ -587,7 +588,28 @@ if args.quantization in ["gptq", "int8"]:
     dprint(model)
     dprint("=" * 60 + "\n")
 
-tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+try:
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+except KeyError as err:
+    if args.tokenizer:
+        tokenizer_path = args.tokenizer
+    else:
+        tokenizer_path = args.variant
+    transformers_config = AutoConfig.from_pretrained(tokenizer_path)
+    if transformers_config.model_type == "mistral3":
+        # NOTE: mistral-small-3.2 doesn't come with its own tokenizer
+        # so here we rely on 3.1's tokenizer
+        # NOTE: the reason we are not using mistral tokenizer from mistral_common is to:
+        # 1. Rest of the script assumes tokenizer to be HF and have properties like `bos_token`
+        # 2. Avoid bunch of extra dependencies
+        warnings.warn("""
+            Unable to fetch mistral model, using Mistral-Small-3.1 manually. If different one required,
+            please configure it manually via args.tokenizer
+        """)
+        tokenizer = AutoTokenizer.from_pretrained(
+            "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+        )
+
 model.eval()
 torch.set_grad_enabled(False)
 loading_model_time = time.time() - loading_model_time

--- a/aiu_fms_testing_utils/scripts/inference.py
+++ b/aiu_fms_testing_utils/scripts/inference.py
@@ -735,7 +735,11 @@ if args.fixed_prompt_length != 0 and args.fixed_prompt_length < max_len:
     exit(1)
 prompts = truncate_prompts_to_max_length(prompts, max_len, max_allowed_length)
 if has_padding:
-    ids, extra_generation_kwargs = pad_input_ids(prompts, min_pad_length=padding_length)
+    ids, extra_generation_kwargs = pad_input_ids(
+        prompts,
+        min_pad_length=padding_length,
+        pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None
+    )
 else:
     ids = prompts
     if isinstance(ids, list) and len(ids) == 1:
@@ -827,6 +831,7 @@ def infer(use_cache, do_sample, warmup, is_multimodal=False):
         do_sample=do_sample,
         timing=args.timing,
         eos_token_id=eos_token_id,
+        pad_token_id=tokenizer.pad_token_id if hasattr(tokenizer, 'pad_token_id') else None,
         extra_kwargs=extra_generation_kwargs,
         **attention_specific_kwargs,
     )

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -266,6 +266,7 @@ def extract_validation_information(
     last_n_tokens=0,
     timing="",
     prefill_chunk_size=0,
+    prepare_model_inputs_hook=None,
     **extra_kwargs,
 ):
     attention_specific_kwargs = {}
@@ -273,7 +274,6 @@ def extract_validation_information(
         from aiu_fms_testing_utils.utils.paged import generate
 
         attention_specific_kwargs["prefill_chunk_size"] = prefill_chunk_size
-        attention_specific_kwargs["pad_token_id"] = pad_token_id
     else:
         # TODO: Add a unified generation dependent on attn_type
         from fms.utils.generation import generate
@@ -296,7 +296,9 @@ def extract_validation_information(
         do_sample=False,
         post_iteration_hook=post_iteration_hook,
         eos_token_id=eos_token_id,
+        pad_token_id=pad_token_id,
         timing=timing,
+        prepare_model_inputs_hook=prepare_model_inputs_hook,
         extra_kwargs=extra_generation_kwargs,
         **attention_specific_kwargs,
     )

--- a/aiu_fms_testing_utils/testing/validation.py
+++ b/aiu_fms_testing_utils/testing/validation.py
@@ -262,6 +262,7 @@ def extract_validation_information(
     post_iteration_hook,
     attn_algorithm=None,
     eos_token_id=None,
+    pad_token_id=None,
     last_n_tokens=0,
     timing="",
     prefill_chunk_size=0,
@@ -272,6 +273,7 @@ def extract_validation_information(
         from aiu_fms_testing_utils.utils.paged import generate
 
         attention_specific_kwargs["prefill_chunk_size"] = prefill_chunk_size
+        attention_specific_kwargs["pad_token_id"] = pad_token_id
     else:
         # TODO: Add a unified generation dependent on attn_type
         from fms.utils.generation import generate

--- a/aiu_fms_testing_utils/utils/__init__.py
+++ b/aiu_fms_testing_utils/utils/__init__.py
@@ -55,6 +55,7 @@ def warmup_model(
     use_cache: bool = True,
     stagger_update_lazyhandle: int = 0,
     prefill_chunk_size: int = 0,
+    is_multimodal=False,
     **extra_kwargs,
 ):
     import torch_sendnn
@@ -90,6 +91,11 @@ def warmup_model(
             )
 
     extra_kwargs = {**_extra_kwargs, "last_n_tokens": 64 if "paged" in attn_name else 1}
+
+    if is_multimodal and hasattr(model, "prepare_inputs_for_generation"):
+        attention_specific_kwargs["prepare_model_inputs_hook"] = (
+            model.prepare_inputs_for_generation
+        )
 
     with stagger_region(stagger_update_lazyhandle):
         with torch_sendnn.warmup_mode():

--- a/aiu_fms_testing_utils/utils/model_setup.py
+++ b/aiu_fms_testing_utils/utils/model_setup.py
@@ -169,3 +169,8 @@ def print_model_params(model: nn.Module, args: argparse.Namespace) -> None:
         )
     dprint(model)
     dprint("=" * 60 + "\n")
+
+
+def requires_embedding_inputs(model_config):
+    """Determine if we should use embeddings as inputs (currently only multimodal)."""
+    return hasattr(model_config, "text_config")

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -10,6 +10,7 @@ from aiu_fms_testing_utils.utils import get_pad_size
 
 logger = logging.getLogger(__name__)
 
+
 def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
     """
     Adjusts the inputs to a batch. Batch size 1 cannot be handled since we want a symbolic shape for the batch
@@ -28,9 +29,11 @@ def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
         kwargs["position_ids"] = position_ids[0].repeat(2, 1)
     return input_ids, kwargs
 
+
 def _requires_embedding_inputs(model_config):
     """Determine if we should use embeddings as inputs (currently only multimodal)."""
     return hasattr(model_config, "text_config")
+
 
 def _get_text_config(model_config):
     """Extract the text config from the model; if it's multimodal, all settings
@@ -38,8 +41,9 @@ def _get_text_config(model_config):
     if text_config := getattr(model_config, "text_config", None):
         logger.info("This model is multimodal - using the text subconfig!")
         return text_config
-    return model_config    
-    
+    return model_config
+
+
 def _infer_model_dtype(model):
     """Try to infer the dtype from the model."""
 
@@ -48,7 +52,7 @@ def _infer_model_dtype(model):
     if len(types_set) == 1:
         model_dtype = types_set.pop()
         return model_dtype
-    
+
     # FIXME - this is super hacky, but leaving it to
     # match existing behavior to avoid changing it in
     # multimodal support PR.
@@ -61,6 +65,7 @@ def _infer_model_dtype(model):
         logger.warning("Unable to infer model weight type")
         model_dtype = torch.float32
     return model_dtype
+
 
 def _infer_kv_heads(text_config):
     """Given the model config, or text config (in multimodal case), determine the number
@@ -329,8 +334,11 @@ def generate(
         if prepare_model_inputs_hook is not None:
             input_ids, kwargs = prepare_model_inputs_hook(i, input_ids, kwargs)
             if is_multimodal and input_ids.ndim != 3:
-                logger.warning("The model is multimodal, but iteration %s's prepare hook did not yield 3D embeddings (typically shape [bsz, seq_len, emb_dim], got %s)", i, list(input_ids.shape))
-
+                logger.warning(
+                    "The model is multimodal, but iteration %s's prepare hook did not yield 3D embeddings (typically shape [bsz, seq_len, emb_dim], got %s)",
+                    i,
+                    list(input_ids.shape),
+                )
 
         # prefill
         if i == 0:
@@ -502,7 +510,6 @@ def generate(
                         # if we have it.
                         if input_ids_seq_chunk.ndim == 3:
                             torch._dynamo.mark_static(input_ids_seq_chunk, 2)
-
 
                         # seq dynamic
                         torch._dynamo.mark_dynamic(input_ids_seq_chunk, 1)

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, MutableMapping, Optional, Tuple, Union
 import torch
 import fms.utils.spyre.paged  # noqa
 from aiu_fms_testing_utils.utils import get_pad_size
+from aiu_fms_testing_utils.utils.model_setup import requires_embedding_inputs
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +29,6 @@ def adjust_inputs_to_batch(input_ids: torch.Tensor, **extra_kwargs):
     if position_ids is not None:
         kwargs["position_ids"] = position_ids[0].repeat(2, 1)
     return input_ids, kwargs
-
-
-def _requires_embedding_inputs(model_config):
-    """Determine if we should use embeddings as inputs (currently only multimodal)."""
-    return hasattr(model_config, "text_config")
 
 
 def _get_text_config(model_config):
@@ -177,7 +173,7 @@ def generate(
     )
 
     ### Multimodal related
-    is_multimodal = _requires_embedding_inputs(model.config)
+    is_multimodal = requires_embedding_inputs(model.config)
     text_config = _get_text_config(model.config)
     if is_multimodal and prepare_model_inputs_hook is None:
         # Best effort warning about what to pass for the post iteration hook;

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -455,15 +455,18 @@ def generate(
                         print(f"[CHUNK DEBUG] position_ids range: min={position_ids_seq_chunk.min()}, max={position_ids_seq_chunk.max()}")
                         print(f"[CHUNK DEBUG] position_ids first 10: {position_ids_seq_chunk[:10]}")
                         print(f"[CHUNK DEBUG] slot_mapping first 10: {slot_mapping_seq_chunk[:10]}")
-                        print(f"[CHUNK DEBUG] Number of padding tokens (position_id==0): {(position_ids_seq_chunk == 0).sum()}")
 
                         # Calculate left_padded_prompt_mask AFTER adding padding
                         # Count the number of position_ids that are 0 (padding positions)
-                        left_padded_prompt_mask_seq_chunk = (
-                            (position_ids_seq_chunk == 0).sum() - 1
-                        ).unsqueeze(0)
+                        num_padding_tokens = (position_ids_seq_chunk == 0).sum()
+                        print(f"[CHUNK DEBUG] Number of padding tokens (position_id==0): {num_padding_tokens}")
 
-                        print(f"[DEBUG] Chunk {chunk_j}: left_padded_prompt_mask_seq_chunk: {left_padded_prompt_mask_seq_chunk}")
+                        # If there are padding tokens, the mask is (count - 1) to get the index of the last padding token
+                        # If there are no padding tokens, the mask is 0 (no left padding)
+                        if num_padding_tokens > 0:
+                            left_padded_prompt_mask_seq_chunk = (num_padding_tokens - 1).unsqueeze(0)
+                        else:
+                            left_padded_prompt_mask_seq_chunk = torch.tensor([0], dtype=torch.int64)
 
                         # Call prepare_model_inputs_hook AFTER padding for chunked prefill
                         # This is needed for multimodal models to convert padded token IDs to embeddings
@@ -476,12 +479,6 @@ def generate(
                             input_ids_seq_chunk, chunk_kwargs = prepare_model_inputs_hook(
                                 i, input_ids_seq_chunk, chunk_kwargs
                             )
-
-                            if prepare_model_inputs_hook is not None:
-                                print(f"[DEBUG] Chunk {chunk_j}: After hook, input_ids_seq_chunk shape: {input_ids_seq_chunk.shape}")
-                                print(f"[DEBUG] Chunk {chunk_j}: After hook, input_ids_seq_chunk dtype: {input_ids_seq_chunk.dtype}")
-                                if input_ids_seq_chunk.ndim == 3:
-                                    print(f"[DEBUG] Chunk {chunk_j}: Embeddings shape (should be [1, 64, emb_dim]): {input_ids_seq_chunk.shape}")
                             # Update position_ids and slot_mapping from the hook if modified
                             position_ids_seq_chunk = chunk_kwargs.get("position_ids", position_ids_seq_chunk)
                             slot_mapping_seq_chunk = chunk_kwargs.get("slot_mapping", slot_mapping_seq_chunk)
@@ -515,8 +512,11 @@ def generate(
                             f"Chunk size mismatch for position_ids. Expected {chunk_size}, got {position_ids_seq_chunk.size(1)}"
                         )
 
+                        # current_tkv_mask should be the number of tokens in THIS chunk, not cumulative
+                        # The cumulative information is encoded in block_table and slot_mapping
+                        chunk_size = chunk_end - chunk_start
                         current_tkv_mask_seq_chunk = torch.tensor(
-                            chunk_end, dtype=torch.int64
+                            chunk_size, dtype=torch.int64
                         ).unsqueeze(0)
 
                         # Calculate block_table for this chunk

--- a/aiu_fms_testing_utils/utils/paged.py
+++ b/aiu_fms_testing_utils/utils/paged.py
@@ -87,6 +87,7 @@ def generate(
     use_cache: bool = False,
     prefill_chunk_size: int = 0,
     eos_token_id: Optional[int] = None,
+    pad_token_id: Optional[int] = None,
     timing: str = "",
     prepare_model_inputs_hook: Optional[
         Callable[
@@ -202,7 +203,12 @@ def generate(
     # if the user provides a hint to the number of blocks to use, use it directly
     NUM_BLOCKS = kwargs.get("_kvcache_num_blocks_hint")
     if NUM_BLOCKS is None:
-        NUM_BLOCKS = (_MAX_BATCH * _MAX_CONTEXT_LENGTH) // BLOCK_SIZE
+        # Use VLLM_DT_MAX_BATCH_TKV_LIMIT if available to deduce NUM_BLOCKS
+        _MAX_BATCH_TKV_LIMIT = os.environ.get("VLLM_DT_MAX_BATCH_TKV_LIMIT")
+        if _MAX_BATCH_TKV_LIMIT is not None:
+            NUM_BLOCKS = int(_MAX_BATCH_TKV_LIMIT) // BLOCK_SIZE
+        else:
+            NUM_BLOCKS = (_MAX_BATCH * _MAX_CONTEXT_LENGTH) // BLOCK_SIZE
 
     model_dtype = _infer_model_dtype(model)
     logger.debug("Inferred model weight dtype %s", model_dtype)
@@ -324,20 +330,24 @@ def generate(
     for i in range(max_new_tokens):
         input_ids = next_input[:, -max_possible_context_length:]
 
-        # Call the prepare model hook if we have one, which is generally for
-        # multimodal. NOTE: in most cases, input_ids are actually embeddings,
-        # i.e., we're going from [bsz, seq_len] -> [bsz, seq_len, emb_dim].
-        if prepare_model_inputs_hook is not None:
-            input_ids, kwargs = prepare_model_inputs_hook(i, input_ids, kwargs)
-            if is_multimodal and input_ids.ndim != 3:
-                logger.warning(
-                    "The model is multimodal, but iteration %s's prepare hook did not yield 3D embeddings (typically shape [bsz, seq_len, emb_dim], got %s)",
-                    i,
-                    list(input_ids.shape),
-                )
-
         # prefill
         if i == 0:
+            # For chunked prefill with multimodal, we need to handle padding BEFORE
+            # calling prepare_model_inputs_hook, since the hook converts token IDs
+            # to embeddings and we can't add token padding to embeddings
+            if prefill_chunk_size > 0 and prepare_model_inputs_hook is not None:
+                # Skip calling the hook here for chunked prefill - it will be called
+                # inside the chunked loop (lines 462-473) after padding is applied
+                pass
+            elif prepare_model_inputs_hook is not None:
+                # For non-chunked prefill, call the hook now
+                input_ids, kwargs = prepare_model_inputs_hook(i, input_ids, kwargs)
+                if is_multimodal and input_ids.ndim != 3:
+                    logger.warning(
+                        "The model is multimodal, but iteration %s's prepare hook did not yield 3D embeddings (typically shape [bsz, seq_len, emb_dim], got %s)",
+                        i,
+                        list(input_ids.shape),
+                    )
             kwargs["mask"] = kwargs["mask"].unsqueeze(1)
 
             outputs_list = []
@@ -378,32 +388,21 @@ def generate(
                 last_n_tokens = kwargs.get("last_n_tokens", 0)
 
                 if prefill_chunk_size > 0:
-                    required_extra_pads = (
-                        get_pad_size(current_tkv.item(), prefill_chunk_size)
-                        - current_tkv.item()
-                    )
-                    left_padded_prompt_mask_seq_chunk = (
-                        (kwargs["position_ids"][seq_i][-current_tkv.item() :] == 0).sum(
-                            dim=0
-                        )
-                        - 1
-                        + required_extra_pads
-                    )
-                    left_padded_prompt_mask_seq_chunk = (
-                        left_padded_prompt_mask_seq_chunk.unsqueeze(0)
-                    )
-                    block_seq_left_padding = required_extra_pads // BLOCK_SIZE
+                    # current_tkv is already padded to a multiple of BLOCK_SIZE (line 287-289)
+                    # so we don't need to add extra padding
+                    assert current_tkv % BLOCK_SIZE == 0, f"current_tkv {current_tkv} must be a multiple of BLOCK_SIZE {BLOCK_SIZE}"
+
+                    print(f"\n[CHUNK DEBUG] Sequence {seq_i}: current_tkv={current_tkv}, prefill_chunk_size={prefill_chunk_size}")
+                    print(f"[CHUNK DEBUG] Sequence {seq_i}: Total chunks to process: {math.ceil(current_tkv / prefill_chunk_size)}")
 
                     # Chunked prefill
                     for chunk_j in range(math.ceil(current_tkv / prefill_chunk_size)):
                         # chunk_start and chunk_end are the index mappings from the original sequence
-                        if chunk_j == 0:
-                            chunk_start = 0
-                            chunk_end = prefill_chunk_size - required_extra_pads
-                        else:
-                            required_extra_pads = 0
-                            chunk_start = chunk_end
-                            chunk_end += prefill_chunk_size
+                        chunk_start = chunk_j * prefill_chunk_size
+                        chunk_end = min((chunk_j + 1) * prefill_chunk_size, current_tkv.item())
+
+                        print(f"\n[CHUNK DEBUG] === Chunk {chunk_j} ===")
+                        print(f"[CHUNK DEBUG] chunk_start={chunk_start}, chunk_end={chunk_end}, chunk_size={chunk_end - chunk_start}")
 
                         input_ids_seq_chunk = input_ids[seq_i][-current_tkv:][
                             chunk_start:chunk_end
@@ -415,12 +414,19 @@ def generate(
                             -current_tkv:
                         ][chunk_start:chunk_end]
 
-                        # add the extra required padding to chunk
+                        # Calculate required padding to align chunk to BLOCK_SIZE boundary
+                        chunk_size = chunk_end - chunk_start
+                        required_extra_pads = (BLOCK_SIZE - (chunk_size % BLOCK_SIZE)) % BLOCK_SIZE
+
+                        print(f"[CHUNK DEBUG] chunk_size={chunk_size}, required_extra_pads={required_extra_pads}")
+
+                        # Add the extra required padding to chunk
                         if required_extra_pads > 0:
                             input_ids_seq_chunk = torch.cat(
                                 (
-                                    torch.zeros(
-                                        required_extra_pads,
+                                    torch.full(
+                                        (required_extra_pads,),
+                                        pad_token_id,
                                         dtype=torch.int64,
                                         device=input_ids_seq_chunk.device,
                                     ),
@@ -444,45 +450,92 @@ def generate(
 
                         input_ids_seq_chunk = input_ids_seq_chunk.unsqueeze(0).clone()
 
-                        slot_mapping_seq_chunk = (
-                            torch.tensor(
+                        print(f"[CHUNK DEBUG] After padding: input_ids_seq_chunk shape: {input_ids_seq_chunk.shape}")
+                        print(f"[CHUNK DEBUG] First 10 token IDs: {input_ids_seq_chunk[0, :10]}")
+                        print(f"[CHUNK DEBUG] position_ids range: min={position_ids_seq_chunk.min()}, max={position_ids_seq_chunk.max()}")
+                        print(f"[CHUNK DEBUG] position_ids first 10: {position_ids_seq_chunk[:10]}")
+                        print(f"[CHUNK DEBUG] slot_mapping first 10: {slot_mapping_seq_chunk[:10]}")
+                        print(f"[CHUNK DEBUG] Number of padding tokens (position_id==0): {(position_ids_seq_chunk == 0).sum()}")
+
+                        # Calculate left_padded_prompt_mask AFTER adding padding
+                        # Count the number of position_ids that are 0 (padding positions)
+                        left_padded_prompt_mask_seq_chunk = (
+                            (position_ids_seq_chunk == 0).sum() - 1
+                        ).unsqueeze(0)
+
+                        print(f"[DEBUG] Chunk {chunk_j}: left_padded_prompt_mask_seq_chunk: {left_padded_prompt_mask_seq_chunk}")
+
+                        # Call prepare_model_inputs_hook AFTER padding for chunked prefill
+                        # This is needed for multimodal models to convert padded token IDs to embeddings
+                        if prepare_model_inputs_hook is not None:
+                            # Create a temporary kwargs for the chunk
+                            chunk_kwargs = {
+                                "position_ids": position_ids_seq_chunk,
+                                "slot_mapping": slot_mapping_seq_chunk,
+                            }
+                            input_ids_seq_chunk, chunk_kwargs = prepare_model_inputs_hook(
+                                i, input_ids_seq_chunk, chunk_kwargs
+                            )
+
+                            if prepare_model_inputs_hook is not None:
+                                print(f"[DEBUG] Chunk {chunk_j}: After hook, input_ids_seq_chunk shape: {input_ids_seq_chunk.shape}")
+                                print(f"[DEBUG] Chunk {chunk_j}: After hook, input_ids_seq_chunk dtype: {input_ids_seq_chunk.dtype}")
+                                if input_ids_seq_chunk.ndim == 3:
+                                    print(f"[DEBUG] Chunk {chunk_j}: Embeddings shape (should be [1, 64, emb_dim]): {input_ids_seq_chunk.shape}")
+                            # Update position_ids and slot_mapping from the hook if modified
+                            position_ids_seq_chunk = chunk_kwargs.get("position_ids", position_ids_seq_chunk)
+                            slot_mapping_seq_chunk = chunk_kwargs.get("slot_mapping", slot_mapping_seq_chunk)
+
+                        # Convert slot_mapping to tensor if it's still a list
+                        if not isinstance(slot_mapping_seq_chunk, torch.Tensor):
+                            slot_mapping_seq_chunk = torch.tensor(
                                 slot_mapping_seq_chunk,
                                 dtype=torch.int64,
                             )
-                            .unsqueeze(0)
-                            .clone()
+                        if slot_mapping_seq_chunk.ndim == 1:
+                            slot_mapping_seq_chunk = slot_mapping_seq_chunk.unsqueeze(0)
+                        slot_mapping_seq_chunk = slot_mapping_seq_chunk.clone()
+
+                        # Add batch dimension to position_ids if needed
+                        if position_ids_seq_chunk.ndim == 1:
+                            position_ids_seq_chunk = position_ids_seq_chunk.unsqueeze(0)
+                        position_ids_seq_chunk = position_ids_seq_chunk.clone()
+
+                        # Verify chunk sizes match
+                        chunk_size = chunk_end - chunk_start
+                        assert input_ids_seq_chunk.size(1) == chunk_size, (
+                            f"Chunk size mismatch for input_ids. Expected {chunk_size}, got {input_ids_seq_chunk.size(1)}"
                         )
 
-                        position_ids_seq_chunk = position_ids_seq_chunk.unsqueeze(
-                            0
-                        ).clone()
-
-                        assert input_ids_seq_chunk.size(1) == prefill_chunk_size, (
-                            f"prefill chunk size was not equal to the chunk size for input_ids. Found {input_ids_seq_chunk.size(0)}"
+                        assert slot_mapping_seq_chunk.size(1) == chunk_size, (
+                            f"Chunk size mismatch for slot_mapping. Expected {chunk_size}, got {slot_mapping_seq_chunk.size(1)}"
                         )
 
-                        assert slot_mapping_seq_chunk.size(1) == prefill_chunk_size, (
-                            f"prefill chunk size was not equal to the chunk size for slot_mapping. Found {slot_mapping_seq_chunk.size(0)}"
-                        )
-
-                        assert position_ids_seq_chunk.size(1) == prefill_chunk_size, (
-                            f"prefill chunk size was not equal to the chunk size for position_ids. Found {position_ids_seq_chunk.size(0)}"
+                        assert position_ids_seq_chunk.size(1) == chunk_size, (
+                            f"Chunk size mismatch for position_ids. Expected {chunk_size}, got {position_ids_seq_chunk.size(1)}"
                         )
 
                         current_tkv_mask_seq_chunk = torch.tensor(
-                            (chunk_j + 1) * prefill_chunk_size, dtype=torch.int64
+                            chunk_end, dtype=torch.int64
                         ).unsqueeze(0)
 
-                        block_end = chunk_end // BLOCK_SIZE
-                        # length of padding or index until padding has occured in block table
+                        # Calculate block_table for this chunk
+                        block_start = chunk_start // BLOCK_SIZE
+                        block_end = (chunk_end + BLOCK_SIZE - 1) // BLOCK_SIZE
+                        # length of padding or index until padding has occurred in block table
                         block_pad_len = (input_ids.shape[1] - current_tkv) // BLOCK_SIZE
                         block_table_seq_chunk = torch.tensor(
-                            [pad_block_id] * (block_seq_left_padding)
-                            + block_table[seq_i][
-                                block_pad_len : block_pad_len + block_end
+                            block_table[seq_i][
+                                block_pad_len + block_start : block_pad_len + block_end
                             ],
                             dtype=torch.int64,
                         ).unsqueeze(0)
+
+                        print(f"[CHUNK DEBUG] left_padded_prompt_mask: {left_padded_prompt_mask_seq_chunk}")
+                        print(f"[CHUNK DEBUG] current_tkv_mask: {current_tkv_mask_seq_chunk} (should be {chunk_end})")
+                        print(f"[CHUNK DEBUG] block_start={block_start}, block_end={block_end}, block_pad_len={block_pad_len}")
+                        print(f"[CHUNK DEBUG] block_table: {block_table_seq_chunk}")
+                        print(f"[CHUNK DEBUG] block_table length: {block_table_seq_chunk.size(1)}")
 
                         chunked_kwargs = {
                             "slot_mapping": slot_mapping_seq_chunk,
@@ -513,9 +566,39 @@ def generate(
                         torch._dynamo.mark_dynamic(position_ids_seq_chunk, 1)
                         torch._dynamo.mark_dynamic(block_table_seq_chunk, 1)
 
+                        print(f"[DEBUG PREFILL] Chunk {chunk_j}: Calling model")
+                        print(f"[DEBUG PREFILL] Chunk {chunk_j}: input_ids_seq_chunk shape: {input_ids_seq_chunk.shape}, dtype: {input_ids_seq_chunk.dtype}")
+                        if input_ids_seq_chunk.ndim == 2:
+                            print(f"[DEBUG PREFILL] Chunk {chunk_j}: First 10 token IDs: {input_ids_seq_chunk[0, :10]}")
+                        elif input_ids_seq_chunk.ndim == 3:
+                            print(f"[DEBUG PREFILL] Chunk {chunk_j}: Embeddings - shape: {input_ids_seq_chunk.shape}")
+                            print(f"[DEBUG PREFILL] Chunk {chunk_j}: Embeddings - first token first 5 dims: {input_ids_seq_chunk[0, 0, :5]}")
+                        print(f"[DEBUG PREFILL] Chunk {chunk_j}: position_ids shape: {position_ids_seq_chunk.shape}")
+                        print(f"[DEBUG PREFILL] Chunk {chunk_j}: position_ids: {position_ids_seq_chunk[0, :10]}")
+                        print(f"[DEBUG PREFILL] Chunk {chunk_j}: left_padded_prompt_mask: {left_padded_prompt_mask_seq_chunk}")
+                        print(f"[DEBUG PREFILL] Chunk {chunk_j}: current_tkv_mask: {current_tkv_mask_seq_chunk}")
+
                         logits, current_kv_cache = model(
                             input_ids_seq_chunk, **chunked_kwargs
                         )
+
+                        print(f"\n[CHUNK DEBUG] === After Model Forward ===")
+                        print(f"[CHUNK DEBUG] logits shape: {logits.shape}")
+                        print(f"[CHUNK DEBUG] Logits stats: min={logits.min():.4f}, max={logits.max():.4f}, mean={logits.mean():.4f}")
+
+                        # Check last token prediction
+                        last_token_logits = logits[0, -1, :]
+                        probs = torch.softmax(last_token_logits, dim=-1)
+                        top5 = torch.topk(probs, 5)
+                        print(f"[CHUNK DEBUG] Last token top 5 predictions:")
+                        print(f"  Token IDs: {top5.indices}")
+                        print(f"  Probabilities: {top5.values}")
+
+                        # Check if there are any NaN or Inf values
+                        if torch.isnan(logits).any():
+                            print(f"[CHUNK DEBUG] WARNING: NaN values detected in logits!")
+                        if torch.isinf(logits).any():
+                            print(f"[CHUNK DEBUG] WARNING: Inf values detected in logits!")
 
                         # only last token must be handled here to properly stack the tensors
                         logits = logits[:, -1, :]
@@ -574,6 +657,16 @@ def generate(
             output = (torch.stack(outputs_list), current_kv_cache)
         # decode
         else:
+            # Call the prepare model hook for decode phase if we have one
+            if prepare_model_inputs_hook is not None:
+                input_ids, kwargs = prepare_model_inputs_hook(i, input_ids, kwargs)
+                if is_multimodal and input_ids.ndim != 3:
+                    logger.warning(
+                        "The model is multimodal, but iteration %s's prepare hook did not yield 3D embeddings (typically shape [bsz, seq_len, emb_dim], got %s)",
+                        i,
+                        list(input_ids.shape),
+                    )
+
             # prepare any padding keyword arguments
             # iteration 0 is the prefill step (cache has not been filled yet), so no need to extend the mask/position_ids
 
@@ -639,6 +732,13 @@ def generate(
                 torch._dynamo.mark_static(input_ids, 2)
 
             logits, past_key_value_states = model(input_ids, **kwargs)
+
+            print(f"[DEBUG] Decode iteration {i}: logits shape: {logits.shape}")
+            print(f"[DEBUG] Decode iteration {i}: Top 5 token probs:")
+            probs = torch.softmax(logits, dim=-1)
+            top5 = torch.topk(probs[0], 5)
+            print(f"  Token IDs: {top5.indices}")
+            print(f"  Probabilities: {top5.values}")
 
             # typically this is done outside of prefill/decode logic, but since this logic already exists as part of the
             # conditional for prefill (since prefill does this within a loop for each batch size 1 prefill), we also provide


### PR DESCRIPTION
### Description

- Uses embedding inputs for multimodal models
- If it's multimodal (i.e., has a text_config as a subconfig), pull opts from the text_config
-  If all named params are the same dtype, use that dtype for the kv cache (otherwise falls back to existing behavior)
    - The existing fallback to float32 is pretty dangerous - with the above change, hopefully this should not really occur (assuming weights are mostly homogeneous for a given model). We should really not assume a default dtype for the model, since mismatches will break at decode time
- Started to pull some of the hackery around figuring out things like kv heads etc into small helpers to be a bit more clear
- Allow passing a prepare_model_inputs_hook to run multimodal models' prepare_inputs_for_generation to get the merged mm/text embeddings.
- If we have input_ids that are 3D, the final dimension is marked as static for compile since it's the embedding dim. When this is eventually consolidated with generate in FMS ([ref](https://github.com/foundation-model-stack/foundation-model-stack/blob/v1.6.0/fms/utils/generation.py#L274)) it would be better to be better about variable names, but for now it's keeping the same naming convention as FMS intentionally, since most of this code is based on generate there.


### Things to Test
1. Inference.py
    - granite
        - [ ] inference.py with paged attention and chunked prefill
        - [ ] inference.py with paged attention but without chunked prefill
        - [ ] inference.py with sdpa
    - mistral
        - [ ] inference.py with paged attention and chunked prefill
        - [ ] inference.py with paged attention but without chunked prefill
        - [ ] inference.py with sdpa
2. DPP


Continuation of : https://github.com/foundation-model-stack/aiu-fms-testing-utils/pull/188