### PR TITLE
Fix import in DPP

### DIFF
--- a/aiu_fms_testing_utils/scripts/drive_paged_programs.py
+++ b/aiu_fms_testing_utils/scripts/drive_paged_programs.py
@@ -1,6 +1,6 @@
 import argparse
 from dataclasses import dataclass
-from datetime import datetime
+import datetime
 import itertools
 import json
 import os


### PR DESCRIPTION
Recently there have been changes made to the script that got subsequently removed. As part of those changes the import got changed but it wasn't restored to it's original, causing [this line](https://github.com/foundation-model-stack/aiu-fms-testing-utils/blob/9eb132795d3a83118821af55c8e828e67931186a/aiu_fms_testing_utils/scripts/drive_paged_programs.py#L545) to trigger an error. With this change I am able to run again.