### PR TITLE
Update fms-model-optimizer to version 0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers=[
 ]
 dependencies = [
 "ibm-fms>=1.1.0,<2.0",
-"fms-model-optimizer[fp8]>=0.5.0,<1.0",
+"fms-model-optimizer[fp8-infer]>=0.8.3,<1.0",
 "sentencepiece>=0.2.0,<0.3.0",
 "numpy>=1.26.4,<2.3.0",
 "transformers>=4.45,<=4.58",


### PR DESCRIPTION
This version has the `fp8-infer` extra that doesn't pull in the llmcompressor dependency. The llmcompressor library is not compatible with the latest version of transformers or compressed-tensors and causes dependency conflicts with other dependencies of vllm and sendnn-inference.