### PR TITLE
fix(cpu-data-script): add attention mapping and context length config

### DIFF
--- a/aiu_fms_testing_utils/scripts/save_cpu_data.py
+++ b/aiu_fms_testing_utils/scripts/save_cpu_data.py
@@ -83,7 +83,7 @@ attn_name = attention_map[args.attention_type]
 is_fp8 = "fp8" in attn_name
 
 ## Random defaults
-os.environ.setdefault("VLLM_DT_MAX_BATCH_SIZE", "1")
+os.environ.setdefault("VLLM_DT_MAX_BATCH_SIZE", "2")
 
 
 model_variant = args.model_variant

--- a/aiu_fms_testing_utils/scripts/save_cpu_data.py
+++ b/aiu_fms_testing_utils/scripts/save_cpu_data.py
@@ -82,7 +82,7 @@ max_new_tokens = args.max_new_tokens
 attn_name = attention_map[args.attention_type]
 is_fp8 = "fp8" in attn_name
 
-## Random defaults
+## Setting batch size to 2 to avoid CI timeouts on larger batches
 os.environ.setdefault("VLLM_DT_MAX_BATCH_SIZE", "2")
 
 

--- a/aiu_fms_testing_utils/scripts/save_cpu_data.py
+++ b/aiu_fms_testing_utils/scripts/save_cpu_data.py
@@ -83,7 +83,7 @@ attn_name = attention_map[args.attention_type]
 is_fp8 = "fp8" in attn_name
 
 ## Random defaults
-os.environ.setdefault("VLLM_DT_MAX_BATCH_SIZE", "4")
+os.environ.setdefault("VLLM_DT_MAX_BATCH_SIZE", "1")
 
 
 model_variant = args.model_variant

--- a/aiu_fms_testing_utils/scripts/save_cpu_data.py
+++ b/aiu_fms_testing_utils/scripts/save_cpu_data.py
@@ -1,9 +1,11 @@
 import json
+import os
 from aiu_fms_testing_utils.testing.validation import (
     LogitsExtractorHook,
     extract_validation_information,
 )
 from fms.models import get_model
+from fms.utils.generation import pad_input_ids
 from transformers import AutoTokenizer
 # from concurrent.futures import ThreadPoolExecutor
 # Ideally we want this script to fetch data in parallel
@@ -67,9 +69,23 @@ parser.add_argument(
     type=str,
     help="path to dataset",
 )
+
+attention_map = {
+    "sdpa": "sdpa_causal",
+    "paged": "spyre_paged_attn",
+    "math_fp8": "math_fp8",
+    "paged_fp8": "spyre_paged_attn_fp8",
+}
+
 args = parser.parse_args()
 max_new_tokens = args.max_new_tokens
-is_fp8 = "fp8" in args.attention_type
+attn_name = attention_map[args.attention_type]
+is_fp8 = "fp8" in attn_name
+
+## Random defaults
+os.environ.setdefault("VLLM_DT_MAX_BATCH_SIZE", "4")
+
+
 model_variant = args.model_variant
 tokenizer = AutoTokenizer.from_pretrained(model_variant)
 model_path_kwargs = {"variant": model_variant}
@@ -86,17 +102,44 @@ dataset = load_jsonl(args.dataset_path)
 
 
 def process_row(row):
+    import bisect
+
     id = row["id"]
     prompt_text = row["prompt"]
     input_ids = tokenizer.encode(prompt_text)
     print("fetching cpu validation info for id: ", id)
+    BLOCK_SIZE = 64
+    prompt_len = len(input_ids)
+    padded_len = BLOCK_SIZE * ((prompt_len + BLOCK_SIZE - 1) // BLOCK_SIZE)
+    ids, extra_kwargs = pad_input_ids(
+        [torch.tensor(input_ids)], min_pad_length=padded_len
+    )
+    extra_kwargs["attn_name"] = attn_name
+
+    largest_context = ids.shape[1] + max_new_tokens
+    supported_context_lengths = [
+        64,
+        128,
+        256,
+        512,
+        1024,
+        2048,
+        4096,
+        8192,
+        16384,
+        32768,
+    ]
+    idx = bisect.bisect_left(supported_context_lengths, largest_context)
+    os.environ["VLLM_DT_MAX_CONTEXT_LEN"] = str(supported_context_lengths[idx])
+
     with torch.no_grad():
         cpu_validation_info = extract_validation_information(
             validation_model,
-            torch.tensor(input_ids).unsqueeze(0),
+            ids,
             max_new_tokens,
             LogitsExtractorHook(),
             attn_algorithm="math",
+            **extra_kwargs,
         )
     return {"id": id, "input_ids": input_ids, "validation": cpu_validation_info}
 

--- a/aiu_fms_testing_utils/scripts/save_cpu_data.py
+++ b/aiu_fms_testing_utils/scripts/save_cpu_data.py
@@ -129,6 +129,10 @@ def process_row(row):
         16384,
         32768,
     ]
+    assert largest_context <= supported_context_lengths[-1], (
+        f"Required context length {largest_context} exceeds maximum supported "
+        f"context length ({supported_context_lengths[-1]})"
+    )
     idx = bisect.bisect_left(supported_context_lengths, largest_context)
     os.environ["VLLM_DT_MAX_CONTEXT_LEN"] = str(supported_context_lengths[idx])
 


### PR DESCRIPTION
## Summary

  This PR enhances the `save_cpu_data.py` script with additional configuration options for attention mapping and context length management, improving compatibility with VLLM inference settings.

### Changes

  1. Attention Type Mapping (save_cpu_data.py:73-79)
    - Added a mapping dictionary to translate user-provided attention type arguments to internal attention names
    - FP8 detection now uses the mapped attention name for accurate identification
   
  2. Context Length Configuration (save_cpu_data.py:119-132)
    - Added dynamic calculation of required context length based on padded input length + max new tokens
    - Implements binary search (bisect) to find the smallest supported context length that accommodates the request
    - Supported context lengths: 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
    - Sets `VLLM_DT_MAX_CONTEXT_LEN` environment variable accordingly
    
  3. Input Padding (save_cpu_data.py:108-115)
    - Added 64-block aligned padding for input IDs using `pad_input_ids` from `fms.utils.generation` (Similar to `inference.py`)
    - Ensures inputs are properly padded before being passed to the model
    
  4. VLLM Batch Size Tuning
    - Hard-coded `VLLM_DT_MAX_BATCH_SIZE` environment variable to 2 (4 was timing out)